### PR TITLE
Fix critical service registration issues for multiple config entries

### DIFF
--- a/custom_components/hcu_integration/__init__.py
+++ b/custom_components/hcu_integration/__init__.py
@@ -63,6 +63,7 @@ PLATFORM_MAP = {
     "switch": Platform.SWITCH,
     "light": Platform.LIGHT,
     "climate": Platform.CLIMATE,
+    "button": Platform.BUTTON,
 }
 
 # List of integration services (single source of truth for registration/removal)


### PR DESCRIPTION
This commit addresses two critical issues identified in code review:

1. Service Registration/Removal for Multiple Config Entries
   - Added reference counting to track multiple config entries
   - Services are now registered only once on first config entry
   - Services are removed only when last config entry is unloaded
   - Prevents service conflicts when multiple HCUs are configured

2. Fixed Hardcoded Entity Component Access Pattern
   - Replaced internal API access (hass.data["entity_components"])
   - Created _get_entity_from_entity_id() helper function
   - Searches entities through coordinators instead of internal APIs
   - More maintainable and follows HA best practices

Changes:
- Added SERVICE_REGISTER_COUNT_KEY to track active config entries
- Implemented reference counting in async_setup_entry()
- Updated async_unload_entry() to decrement counter and conditionally remove services
- Created helper function to safely locate entities across all coordinators
- Updated handle_play_sound() and handle_activate_party_mode() to use helper
- Added debug logging for service registration/unregistration

These changes ensure the integration works correctly when users have:
- Multiple HCU devices configured
- Need to reload/remove individual config entries
- Multiple instances running simultaneously