### PR TITLE
README.me: update button event section

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Now that you've confirmed your buttons work, let's create automations!
    - Select **Template**
    - Template:
      ```jinja
-     {{ trigger.event.data.device_id == '3014F711A00048240995D6BC' and trigger.event.data.channel == 1 }}     
+     {{ trigger.event.data.device_id == '3014F711A00048240995D6BC' and trigger.event.data.channel == 1 }}
      ```
    - Replace the `device_id` and `channel` with your values!
 5. **Add Action:**


### PR DESCRIPTION
### Description

This PR updates README.md sections regarding button event handling.

In detail:
- `device_id`, `channel`, and `type` in `event.data` are used without quotes:
   <img width="383" height="155" alt="Bildschirmfoto vom 2025-11-07 14-55-21" src="https://github.com/user-attachments/assets/b7080a14-83c8-481f-84cf-be8eddb8960e" />
- `channel` numbers must be given without quotation marks in automations to work, as these are numbers.
- `type` in `event.data` is no longer `press`, but `KEY_PRESS_*`.
- YAML code update of the examples according the current syntax.
- Example added for using short and long press events as switch or dim events.