### PR TITLE
config_flow: fix DateTimeSelector problem for vacation mode

### DIFF
--- a/custom_components/hcu_integration/config_flow.py
+++ b/custom_components/hcu_integration/config_flow.py
@@ -5,7 +5,7 @@ import aiohttp
 import asyncio
 import voluptuous as vol
 from typing import Any, TYPE_CHECKING
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
 from homeassistant.const import CONF_HOST, CONF_TOKEN, ATTR_TEMPERATURE
@@ -455,6 +455,7 @@ class HcuOptionsFlowHandler(OptionsFlow):
                 _LOGGER.exception("Unexpected error activating vacation mode")
                 errors["base"] = "unknown"
 
+        default_end_time = datetime.now() + timedelta(days=7)
         default_temp = self.config_entry.options.get(
             CONF_COMFORT_TEMPERATURE, DEFAULT_COMFORT_TEMPERATURE
         )
@@ -467,7 +468,10 @@ class HcuOptionsFlowHandler(OptionsFlow):
                         ATTR_TEMPERATURE,
                         default=default_temp,
                     ): vol.All(vol.Coerce(float), vol.Range(min=5.0, max=30.0)),
-                    vol.Required(ATTR_END_TIME): selector.DateTimeSelector(),
+                    vol.Required(
+                        ATTR_END_TIME,
+                        default=default_end_time.strftime("%Y-%m-%d %H:%M"),
+                    ): selector.DateTimeSelector(),
                 }
             ),
             errors=errors,


### PR DESCRIPTION
## Description

This PR fixes a problem with the DateTimeSelector when setting the vacation mode in HCU Integration configuration.

When the form for specifying the end date and time for the vacation is opened without specifying a default value in format `yyyy-mm-dd hh:mm`, an error occurs due to an invalid time specification if the date is not changed. For example, if you change only the end time but not the date, the following error occurs:

<img width="482" height="341" alt="Bildschirmfoto vom 2025-11-08 17-57-05" src="https://github.com/user-attachments/assets/d5571378-db99-4890-bf0b-81cfde3451d1" />

Furthermore, `0:00:00` is always used as end time in the form.

This PR therefore computes an end date and time in format `yyyy-mm-dd hh:mm` using an offset of 7 days as the HomematicIP App does and uses it as the default value for the form.

## Test

Open `Devices & Services` -> `Homematic IP Local (HCU)` -> `Config`.

Without this PR, the form displays the current date as the end date and `0:00:00` as the end time. If you then change only the end time, you will get an `Invalid datetime specified` error with a time string that contains two different time definitions, see the screenshot above.

With this PR, the form displays an end date and time with an offset of 7 days, including the time. If you only change the end time, it should work.