### PR TITLE
climate: fix preset mode update for party mode

### DIFF
--- a/custom_components/hcu_integration/climate.py
+++ b/custom_components/hcu_integration/climate.py
@@ -148,7 +148,7 @@ class HcuClimate(HcuGroupBaseEntity, ClimateEntity):
             self._attr_preset_mode = PRESET_BOOST
         elif heating_home.get("absenceType") == "PERMANENT":
             self._attr_preset_mode = PRESET_ECO
-        elif self._group.get("partyMode") == True:
+        elif self._group.get("partyMode"):
             self._attr_preset_mode = PRESET_PARTY
         else:
             active_profile_index = self._group.get("activeProfile")


### PR DESCRIPTION
## Description

This PR fixes preset mode handling for the party mode.

If party mode is activated in the HomematicIP App for a room, the preset mode is not updated in HA. Reason is that the attribute `partyMode` doesn't uses `True` instead of `ACTIVE` in `GROUP_CHANGED` events to indicate that the party mode is activated.

## Test

Without the PR, the preset mode in HA remains in `Standard` mode, when activating the party mode for a room, with the PR, preset mode is updated correctly.

<img width="407" height="450" alt="Bildschirmfoto vom 2025-11-09 18-46-35" src="https://github.com/user-attachments/assets/4c95ef5e-a0fe-4d21-81be-67338d61bcc9" />
