### PR TITLE
Bump version to 1.15.3 for proper HACS release

### DIFF
--- a/custom_components/hcu_integration/manifest.json
+++ b/custom_components/hcu_integration/manifest.json
@@ -8,7 +8,7 @@
   "quality_scale": "silver",
   "codeowners": ["@Ediminator"],
   "requirements": ["aiohttp>=3.0.0"],
-  "version": "1.15.2",
+  "version": "1.15.3",
   "dependencies": [],
   "reconfigure": true,
   "platforms": [


### PR DESCRIPTION
This ensures the manifest.json version matches the git tag, allowing HACS to properly detect and install the update.

Previous releases v1.15.1 and v1.15.2 had incorrect manifest versions (still showing 1.15.0), preventing users from receiving the bug fixes for issues #80, #81, and #82.

This release contains all fixes from:
- PR #84: Issues #80, #81, #82 (BSL events, RGB color, siren state)
- PR #86: HA Core 2025.3 color mode validation
- PR #87: Cover position bug fix