### PR TITLE
Fix missing entities for weather sensors and other devices (Issue #71)

### DIFF
--- a/custom_components/hcu_integration/entity.py
+++ b/custom_components/hcu_integration/entity.py
@@ -171,8 +171,16 @@ class HcuBaseEntity(CoordinatorEntity["HcuCoordinator"], HcuEntityPrefixMixin, E
 
     @property
     def available(self) -> bool:
-        """Return True if the entity is available."""
-        if not self._client.is_connected or not self._device or not self._channel:
+        """Return True if the entity is available.
+
+        Note: We intentionally do NOT check 'not self._channel' here because:
+        - self._channel returns an empty dict {} when channel data is missing
+        - Empty dicts are falsy in Python, causing false unavailability
+        - Many channels may have sparse data or be temporarily omitted from HCU updates
+        - This is normal behavior for devices like weather sensors (HmIP-SWO-PR) and sirens
+        - Device reachability checks (permanentlyReachable and maintenance channel) are sufficient
+        """
+        if not self._client.is_connected or not self._device:
             return False
 
         # Devices that are permanently reachable (e.g., wired/powered devices)


### PR DESCRIPTION
## Root Cause

The base entity's availability check included `if not self._channel`, which evaluates to True when channel data is an empty dict `{}`. This was introduced in commit 2d137f86 (Oct 17, 2025) as part of "Improved Entity Availability".

When `self._channel` returns `{}` (empty dict), Python's `not {}` evaluates to True, causing entities to become unavailable even though devices are reachable. Many channels (weather sensors, sirens, etc.) have sparse data or are temporarily omitted from HCU updates - this is normal HCU behavior.

## Solution

1. **Remove faulty check**: Removed `not self._channel` from HcuBaseEntity.available
2. **Robust availability**: Based solely on client connection, device presence, and device reachability (permanentlyReachable or maintenance channel status)
3. **Updated siren**: Simplified siren's available override to focus on diagnostics
4. **Documentation**: Added detailed comments explaining the intentional omission

## Impact

- Weather sensor entities (HmIP-SWO-PR) remain available with sparse channel data
- All entities more resilient to temporary channel data omissions
- Fixes the same root cause that affected sirens in issue #82
- No more entities disappearing after integration updates

Fixes #71