### PR TITLE
Fix HmIP-BSL multicolor ORANGE support (Issue #112)

### DIFF
--- a/custom_components/hcu_integration/const.py
+++ b/custom_components/hcu_integration/const.py
@@ -730,6 +730,7 @@ HMIP_RGB_COLOR_MAP = {
     HMIP_COLOR_RED: (0, 100),        # Red
     HMIP_COLOR_PURPLE: (300, 100),   # Purple/Magenta
     HMIP_COLOR_YELLOW: (60, 100),    # Yellow
+    HMIP_COLOR_ORANGE: (30, 100),    # Orange
     HMIP_COLOR_WHITE: (0, 0),        # White (will be handled separately with brightness)
 }
 

--- a/custom_components/hcu_integration/light.py
+++ b/custom_components/hcu_integration/light.py
@@ -171,10 +171,12 @@ class HcuLight(HcuBaseEntity, LightEntity):
         if sat < 20:
             return HMIP_COLOR_WHITE
 
-        # Map hue ranges to 7 colors: WHITE, RED, YELLOW, GREEN, TURQUOISE, BLUE, PURPLE
-        if hue < 30 or hue >= 330:
+        # Map hue ranges to 8 colors: WHITE, RED, ORANGE, YELLOW, GREEN, TURQUOISE, BLUE, PURPLE
+        if hue < 15 or hue >= 345:
             return HMIP_COLOR_RED
-        elif 30 <= hue < 90:
+        elif 15 <= hue < 45:
+            return HMIP_COLOR_ORANGE
+        elif 45 <= hue < 90:
             return HMIP_COLOR_YELLOW
         elif 90 <= hue < 150:
             return HMIP_COLOR_GREEN
@@ -182,7 +184,7 @@ class HcuLight(HcuBaseEntity, LightEntity):
             return HMIP_COLOR_TURQUOISE
         elif 210 <= hue < 270:
             return HMIP_COLOR_BLUE
-        else:  # 270 <= hue < 330
+        else:  # 270 <= hue < 345
             return HMIP_COLOR_PURPLE
 
     async def async_turn_on(self, **kwargs) -> None:

--- a/custom_components/hcu_integration/manifest.json
+++ b/custom_components/hcu_integration/manifest.json
@@ -8,7 +8,7 @@
   "quality_scale": "silver",
   "codeowners": ["@Ediminator"],
   "requirements": ["aiohttp>=3.0.0"],
-  "version": "1.15.15",
+  "version": "1.15.16",
   "dependencies": [],
   "reconfigure": true,
   "platforms": [


### PR DESCRIPTION
This fixes the multicolor issue reported in #112 where ORANGE color was not properly supported for HmIP-BSL devices.

Changes:
- Added ORANGE to HMIP_RGB_COLOR_MAP (const.py) with HS values (30, 100)
- Updated HcuLight._hs_to_simple_rgb() to support ORANGE color (hue 15-45)
- Adjusted hue ranges for RED (now <15 or >=345) and YELLOW (now 45-90) to make room for ORANGE
- Bumped version to 1.15.16

The ORANGE color constant was already defined but was missing from the RGB color map, causing Home Assistant to fail when the device reported ORANGE as its current state. Additionally, the HcuLight color conversion method couldn't convert HS colors to ORANGE, preventing users from setting this color.

This fix brings HcuLight's ORANGE support in line with the existing HcuNotificationLight implementation.