### PR TITLE
Fix(siren): Derive state from ALARM_SWITCHING group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the Homematic IP Local (HCU) integration will be document
 
 ---
 
+## Unreleased
+
+### Fixes & Improvements
+
+- **Fix Siren State Detection**: Corrected an issue where the siren entity would always report its state as "off". The integration now correctly derives the siren's on/off state from its associated `ALARM_SWITCHING` group, as the `acousticAlarmActive` field is not provided by the HCU API.
+
 ## 1.15.19 - 2025-11-13
 
 ### Fixes & Improvements

--- a/custom_components/hcu_integration/manifest.json
+++ b/custom_components/hcu_integration/manifest.json
@@ -8,7 +8,7 @@
   "quality_scale": "silver",
   "codeowners": ["@Ediminator"],
   "requirements": ["aiohttp>=3.0.0"],
-  "version": "1.15.19",
+  "version": "1.15.20",
   "dependencies": [],
   "reconfigure": true,
   "platforms": [


### PR DESCRIPTION
The siren entity was previously checking for the `acousticAlarmActive` key in the channel data, which is not provided by the HCU API. This caused the siren to always report its state as 'off'.

This commit refactors the `HcuSiren` entity to determine its `is_on` state from the `on` property of the linked `ALARM_SWITCHING` group, which accurately reflects whether the siren is active.

- Modified `siren.py` to use group state for `is_on` property.
- Removed unused `HMIP_CHANNEL_KEY_ACOUSTIC_ALARM_ACTIVE` from `const.py`.
- Updated logging in `discovery.py` to remove reference to the old key.
- Incremented the version in `manifest.json`.
- Added an entry to `CHANGELOG.md` for the fix.