### PR TITLE
fix(events): Restore missing button channel type mappings (v1.17.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,52 @@ All notable changes to the Homematic IP Local (HCU) integration will be document
 
 ---
 
+## 1.17.1 - 2025-11-17
+
+### 🐛 Critical Bug Fix
+
+**Fix Button Events Completely Broken - Restore Missing Channel Type Mappings**
+
+Fixed a critical regression introduced in v1.17.0 where button events stopped working entirely for devices using certain channel types.
+
+**Root Cause:**
+
+In v1.17.0 (commit d4da009), a refactoring removed the dynamic channel type mapping loop and replaced it with explicit mappings. However, THREE critical channel types were removed from `EVENT_CHANNEL_TYPES` but were NEVER added to `HMIP_CHANNEL_TYPE_TO_ENTITY`:
+- `BRAND_REMOTE_CONTROL`
+- `BRAND_WALL_MOUNTED_TRANSMITTER`
+- `REMOTE_CONTROL_TRANSMITTER`
+
+This caused any device using these channel types to:
+1. NOT have button event entities created during discovery
+2. NOT fire any button events (neither modern entity-based events nor legacy hcu_integration_event)
+3. Be completely non-functional for button presses
+
+**What Was Fixed:**
+
+1. **Restored Missing Channel Types**: Added all three missing channel types back to `EVENT_CHANNEL_TYPES`
+2. **Added Explicit Mappings**: Created explicit `HcuButtonEvent` mappings for all three channel types in `HMIP_CHANNEL_TYPE_TO_ENTITY`
+3. **Comprehensive Coverage**: Ensures all button devices work regardless of which channel type their firmware reports
+
+**Impact:**
+- ✅ Button events now work for ALL button devices
+- ✅ Devices using BRAND_REMOTE_CONTROL, BRAND_WALL_MOUNTED_TRANSMITTER, or REMOTE_CONTROL_TRANSMITTER channel types are now functional
+- ✅ Both modern entity-based events and legacy hcu_integration_event now fire correctly
+- ✅ No breaking changes - existing working devices continue to work
+
+**How to Apply:**
+1. Update to version 1.17.1
+2. Restart Home Assistant
+3. Button events should immediately start working
+
+**Files Changed:**
+- `custom_components/hcu_integration/const.py` - Added missing channel type mappings
+
+**Reported by:** Community users experiencing broken button events after v1.15.20
+**Affects:** Version 1.17.0 (all button devices using the three missing channel types)
+**Fixed in:** Version 1.17.1
+
+---
+
 ## 1.17.0 - 2025-11-17
 
 ### 🐛 Critical Bug Fixes

--- a/custom_components/hcu_integration/const.py
+++ b/custom_components/hcu_integration/const.py
@@ -667,6 +667,10 @@ EVENT_CHANNEL_TYPES = {
     "MULTI_MODE_INPUT_CHANNEL",
     CHANNEL_TYPE_MULTI_MODE_INPUT_TRANSMITTER,
     "KEY_CHANNEL",  # For remote controls and wall-mounted transmitters
+    # Channel types that were missing from the v1.17.0 fix:
+    "BRAND_REMOTE_CONTROL",  # Used by some button devices
+    "BRAND_WALL_MOUNTED_TRANSMITTER",  # Used by some wall-mounted switches
+    "REMOTE_CONTROL_TRANSMITTER",  # Used by some remote controls
     # Note: HmIP-BSL uses NOTIFICATION_LIGHT_CHANNEL for button inputs (channels 2-3)
     # These are multi-function channels that serve as BOTH button inputs AND backlight LEDs
     # Button events are handled via DEVICE_CHANNEL_EVENT, not timestamp-based detection
@@ -715,6 +719,10 @@ HMIP_CHANNEL_TYPE_TO_ENTITY = {
     "SWITCH_INPUT_CHANNEL": {"class": "HcuButtonEvent"},
     "SINGLE_KEY_CHANNEL": {"class": "HcuButtonEvent"},
     "MULTI_MODE_INPUT_CHANNEL": {"class": "HcuButtonEvent"},
+    # Channel types that were missing from the v1.17.0 fix - now restored:
+    "BRAND_REMOTE_CONTROL": {"class": "HcuButtonEvent"},
+    "BRAND_WALL_MOUNTED_TRANSMITTER": {"class": "HcuButtonEvent"},
+    "REMOTE_CONTROL_TRANSMITTER": {"class": "HcuButtonEvent"},
     "ACCELERATION_SENSOR_CHANNEL": None,
     "CLIMATE_CONTROL_CHANNEL": None,
     "CLIMATE_CONTROL_INPUT_CHANNEL": None,

--- a/custom_components/hcu_integration/manifest.json
+++ b/custom_components/hcu_integration/manifest.json
@@ -8,7 +8,7 @@
   "quality_scale": "silver",
   "codeowners": ["@Ediminator"],
   "requirements": ["aiohttp>=3.0.0"],
-  "version": "1.17.0",
+  "version": "1.17.1",
   "dependencies": [],
   "reconfigure": true,
   "platforms": [


### PR DESCRIPTION
Critical fix for button events broken since v1.17.0

Root Cause:
- v1.17.0 (commit d4da009) removed dynamic channel type mapping loop
- Replaced with explicit mappings but forgot THREE channel types:
  * BRAND_REMOTE_CONTROL
  * BRAND_WALL_MOUNTED_TRANSMITTER
  * REMOTE_CONTROL_TRANSMITTER
- Devices using these channel types had NO button event entities created
- Result: button events completely broken for affected devices

The Fix:
1. Added missing channel types back to EVENT_CHANNEL_TYPES
2. Created explicit HcuButtonEvent mappings in HMIP_CHANNEL_TYPE_TO_ENTITY
3. Ensures comprehensive coverage for all button devices

Impact:
- Button events now work for ALL button device channel types
- Both modern entity-based events and legacy events fire correctly
- No breaking changes to working devices

Files Changed:
- const.py: Added 3 missing channel type mappings
- manifest.json: Version bump to 1.17.1
- CHANGELOG.md: Documented root cause and fix

Fixes: Button events broken after release 1.15.20