### PR TITLE
Refactor: Address PR review feedback

### DIFF
--- a/custom_components/hcu_integration/__init__.py
+++ b/custom_components/hcu_integration/__init__.py
@@ -316,7 +316,7 @@ class HcuCoordinator(DataUpdateCoordinator[set[str]]):
                         "Timestamp button press: device=%s, channel=%s (new_ts=%s, old_ts=%s)",
                         device_id, ch_idx, new_timestamp, old_timestamp,
                     )
-                    self._fire_button_event(device_id, ch_idx, "PRESS_SHORT")
+                    self._fire_button_event(device_id, ch_idx, "press")
                     self._trigger_event_entity(device_id, ch_idx)
 
     def _fire_button_event(

--- a/custom_components/hcu_integration/services.py
+++ b/custom_components/hcu_integration/services.py
@@ -75,9 +75,10 @@ def _get_entity_from_entity_id(hass: HomeAssistant, entity_id: str) -> Entity | 
 
 def _get_client_for_service(hass: HomeAssistant) -> HcuApiClient:
     """Get the API client for service calls."""
-    for coordinator in hass.data.get(DOMAIN, {}).values():
-        return coordinator.client
-    raise ValueError("No HCU client available")
+    try:
+        return next(iter(hass.data.get(DOMAIN, {}).values())).client
+    except StopIteration as err:
+        raise ValueError("No HCU client available") from err
 
 
 async def async_handle_play_sound(hass: HomeAssistant, call: ServiceCall) -> None:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto


### PR DESCRIPTION
- Revert timestamp-based button press event type to "press" for backward compatibility.
- Simplify `_get_client_for_service` in `services.py` using `next(iter(...))`.
- Update tests in `tests/test_coordinator.py` to match changes and fix test setup.