### PR TITLE
Refactor: Remove redundant exception handler in services

### DIFF
--- a/custom_components/hcu_integration/services.py
+++ b/custom_components/hcu_integration/services.py
@@ -160,8 +160,6 @@ async def async_handle_activate_vacation_mode(hass: HomeAssistant, call: Service
             end_time=formatted_end_time,
         )
         _LOGGER.info("Activated vacation mode until %s", end_time_str)
-    except (HcuApiError, ConnectionError) as err:
-        _LOGGER.error("Error activating vacation mode: %s", err)
     except (HcuApiError, ConnectionError, ValueError) as err:
         _LOGGER.error("Error activating vacation mode: %s", err)
 


### PR DESCRIPTION
- Removed redundant exception block in `async_handle_activate_vacation_mode` that was left over from previous refactoring.
- The function now correctly uses a single consolidated exception block for `HcuApiError`, `ConnectionError`, and `ValueError`.