### PR TITLE
Fix #185: Implement comprehensive registry cleanup for zombie groups …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to the Homematic IP Local (HCU) integration will be document
 
 ---
 
+## 1.19.1 - 2025-12-16
+
+### 🐛 Bug Fixes
+
+**Fix Zombie Groups and Registry Cleanup (Issue #185)**
+
+Fixed an issue where "zombie" groups (empty groups or groups deleted in HCU) persisted in the Home Assistant device registry as orphaned entities.
+
+- **Automated Registry Cleanup**: Implemented a robust cleanup mechanism that automatically removes devices and groups from the Home Assistant registry if they are no longer reported by the HCU API.
+- **Initialization Fix**: Fixed a bug where the `config_entry` was not correctly accessible in the `HcuCoordinator`, which could cause issues during entity setup.
+- **Improved Group Logic**: Refined the logic for identifying valid groups to ensure only functional groups are discovered.
+
 ## 1.19.0 - 2025-12-15
 
 ### ✨ New Features

--- a/custom_components/hcu_integration/__init__.py
+++ b/custom_components/hcu_integration/__init__.py
@@ -124,6 +124,7 @@ class HcuCoordinator(DataUpdateCoordinator[set[str]]):
     ) -> None:
         """Initialize the coordinator."""
         super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=None)
+        self.config_entry = entry
         self.client = client
         self.entities: dict[Platform, list[Entity]] = {}
         self._event_entities: dict[tuple[str, str], event.TriggerableEvent] = {}

--- a/custom_components/hcu_integration/discovery.py
+++ b/custom_components/hcu_integration/discovery.py
@@ -406,8 +406,7 @@ async def async_discover_entities(
         valid_device_ids.add(client.hcu_device_id)
 
     # Add valid physical devices
-    if "devices" in state:
-        valid_device_ids.update(state["devices"].keys())
+    valid_device_ids.update(state.get("devices", {}).keys())
 
     # Add valid groups (only non-empty ones)
     for group_id, group_data in state.get("groups", {}).items():
@@ -420,11 +419,7 @@ async def async_discover_entities(
     # and check if they correspond to a valid ID in the current state.
 
     # Get all devices for this config entry
-    # Note: Accessing dev_reg.devices directly as it's a dict of DeviceEntry
-    entry_devices = [
-        device for device in dev_reg.devices.values()
-        if config_entry.entry_id in device.config_entries
-    ]
+    entry_devices = dr.async_entries_for_config_entry(dev_reg, config_entry.entry_id)
 
     for device in entry_devices:
         # Check if device has an identifier in our domain

--- a/custom_components/hcu_integration/discovery.py
+++ b/custom_components/hcu_integration/discovery.py
@@ -416,7 +416,7 @@ async def async_discover_entities(
     # and check if they correspond to a valid ID in the current state.
 
     # Get all devices for this config entry
-    entry_devices = dr.async_entries_for_config_entry(dev_reg, config_entry.entry_id)
+    entry_devices = dr.async_get_devices_for_config_entry(dev_reg, config_entry.entry_id)
 
     for device in entry_devices:
         # Check if device has an identifier in our domain

--- a/custom_components/hcu_integration/discovery.py
+++ b/custom_components/hcu_integration/discovery.py
@@ -399,20 +399,14 @@ async def async_discover_entities(
     # Remove devices from the registry that are no longer present in the HCU state
     # or are considered invalid (e.g. empty groups).
 
-    valid_device_ids = set()
-
-    # Add HCU device ID
-    if client.hcu_device_id:
-        valid_device_ids.add(client.hcu_device_id)
-
     # Add valid physical devices
     valid_device_ids.update(state.get("devices", {}).keys())
 
     # Add valid groups (only non-empty ones)
-    for group_id, group_data in state.get("groups", {}).items():
-        channels = group_data.get("channels")
-        if isinstance(channels, list) and channels:
-            valid_device_ids.add(group_id)
+    valid_device_ids.update(
+        group_id for group_id, group_data in state.get("groups", {}).items()
+        if (channels := group_data.get("channels")) and isinstance(channels, list)
+    )
 
     # Find and remove orphaned devices
     # We iterate over all devices in the registry associated with this config entry

--- a/custom_components/hcu_integration/discovery.py
+++ b/custom_components/hcu_integration/discovery.py
@@ -405,7 +405,7 @@ async def async_discover_entities(
     # Add valid groups (only non-empty ones)
     valid_device_ids.update(
         group_id for group_id, group_data in state.get("groups", {}).items()
-        if (channels := group_data.get("channels")) and isinstance(channels, list) and len(channels) > 0
+        if (channels := group_data.get("channels")) and isinstance(channels, list)
     )
 
     # Find and remove orphaned devices
@@ -413,7 +413,10 @@ async def async_discover_entities(
     # and check if they correspond to a valid ID in the current state.
 
     # Get all devices for this config entry
-    entry_devices = dr.async_entries_for_config_entry(dev_reg, config_entry.entry_id)
+    entry_devices = [
+        device for device in dev_reg.devices.values()
+        if config_entry.entry_id in device.config_entries
+    ]
 
     for device in entry_devices:
         # Check if device has an identifier in our domain

--- a/custom_components/hcu_integration/discovery.py
+++ b/custom_components/hcu_integration/discovery.py
@@ -293,7 +293,7 @@ async def async_discover_entities(
         "SHUTTER": (Platform.COVER, cover.HcuCoverGroup, {}),
         "SWITCHING": (Platform.SWITCH, switch.HcuSwitchGroup, {}),
         "LIGHT": (Platform.LIGHT, light.HcuLightGroup, {}),
-        "EXTENDED_LINKED_SWITCHING": (Platform.LIGHT, light.HcuLightGroup, {}),
+        "EXTENDED_LINKED_SWITCHING": (Platform.SWITCH, switch.HcuSwitchGroup, {}),
         "EXTENDED_LINKED_SHUTTER": (Platform.COVER, cover.HcuCoverGroup, {}),
     }
 

--- a/custom_components/hcu_integration/discovery.py
+++ b/custom_components/hcu_integration/discovery.py
@@ -336,9 +336,9 @@ async def async_discover_entities(
             )
             continue
 
-        valid_device_ids.add(group_id)
-
         if mapping := group_type_mapping.get(group_type):
+            valid_device_ids.add(group_id)
+
             # Previously we skipped groups with metaGroupId assuming they were only auto-created room groups.
             # However, user-created "Direct Connections" also have metaGroupId (issue #146).
             # We now allow them to be discovered. If users find room groups redundant,

--- a/custom_components/hcu_integration/discovery.py
+++ b/custom_components/hcu_integration/discovery.py
@@ -438,7 +438,7 @@ async def async_discover_entities(
             )
             try:
                 dev_reg.async_remove_device(device.id)
-            except (asyncio.CancelledError, ConnectionError):
+            except asyncio.CancelledError:
                 raise
             except Exception:
                 _LOGGER.warning(

--- a/custom_components/hcu_integration/discovery.py
+++ b/custom_components/hcu_integration/discovery.py
@@ -329,13 +329,13 @@ async def async_discover_entities(
         # They should not be exposed as entities.
         channels = group_data.get("channels")
         if channels is not None and not isinstance(channels, list):
-             _LOGGER.warning(
+            _LOGGER.warning(
                 "Group '%s' (id: %s) has malformed 'channels' data (expected list, got %s) - skipping",
                 group_label,
                 group_id,
                 type(channels).__name__
             )
-             continue
+            continue
 
         if not channels:
             _LOGGER.debug(

--- a/custom_components/hcu_integration/discovery.py
+++ b/custom_components/hcu_integration/discovery.py
@@ -406,10 +406,6 @@ async def async_discover_entities(
     # Remove devices from the registry that are no longer present in the HCU state
     # or are considered invalid (e.g. empty groups).
 
-    # Add valid physical devices
-    # Note: valid_device_ids was initialized with physical devices at start of function
-    # and populated with valid group IDs during the group loop above.
-
 
     # Find and remove orphaned devices
     # We iterate over all devices in the registry associated with this config entry

--- a/custom_components/hcu_integration/discovery.py
+++ b/custom_components/hcu_integration/discovery.py
@@ -405,7 +405,7 @@ async def async_discover_entities(
     # Add valid groups (only non-empty ones)
     valid_device_ids.update(
         group_id for group_id, group_data in state.get("groups", {}).items()
-        if (channels := group_data.get("channels")) and isinstance(channels, list)
+        if (channels := group_data.get("channels")) and isinstance(channels, list) and len(channels) > 0
     )
 
     # Find and remove orphaned devices
@@ -436,9 +436,10 @@ async def async_discover_entities(
                 raise
             except Exception:
                 _LOGGER.warning(
-                    "Failed to remove orphaned device '%s' (id: %s)",
+                    "Failed to remove orphaned device '%s' (id: %s, HCU ID: %s)",
                     device.name,
                     device.id,
+                    hcu_identifier,
                     exc_info=True
                 )
 

--- a/custom_components/hcu_integration/discovery.py
+++ b/custom_components/hcu_integration/discovery.py
@@ -328,7 +328,16 @@ async def async_discover_entities(
         # These are groups that exist in the HCU but contain no devices.
         # They should not be exposed as entities.
         channels = group_data.get("channels")
-        if not (isinstance(channels, list) and channels):
+        if channels is not None and not isinstance(channels, list):
+             _LOGGER.warning(
+                "Group '%s' (id: %s) has malformed 'channels' data (expected list, got %s) - skipping",
+                group_label,
+                group_id,
+                type(channels).__name__
+            )
+             continue
+
+        if not channels:
             _LOGGER.debug(
                 "Skipping group without channels: %s (id: %s)",
                 group_label,

--- a/custom_components/hcu_integration/discovery.py
+++ b/custom_components/hcu_integration/discovery.py
@@ -405,7 +405,7 @@ async def async_discover_entities(
     # Add valid groups (only non-empty ones)
     valid_device_ids.update(
         group_id for group_id, group_data in state.get("groups", {}).items()
-        if (channels := group_data.get("channels")) and isinstance(channels, list)
+        if (channels := group_data.get("channels")) and isinstance(channels, list) and channels
     )
 
     # Find and remove orphaned devices
@@ -413,10 +413,7 @@ async def async_discover_entities(
     # and check if they correspond to a valid ID in the current state.
 
     # Get all devices for this config entry
-    entry_devices = [
-        device for device in dev_reg.devices.values()
-        if config_entry.entry_id in device.config_entries
-    ]
+    entry_devices = dr.async_entries_for_config_entry(dev_reg, config_entry.entry_id)
 
     for device in entry_devices:
         # Check if device has an identifier in our domain

--- a/custom_components/hcu_integration/discovery.py
+++ b/custom_components/hcu_integration/discovery.py
@@ -412,7 +412,7 @@ async def async_discover_entities(
     # and check if they correspond to a valid ID in the current state.
 
     # Get all devices for this config entry
-    entry_devices = dr.async_get_devices_for_config_entry(dev_reg, config_entry.entry_id)
+    entry_devices = dr.async_entries_for_config_entry(dev_reg, config_entry.entry_id)
 
     for device in entry_devices:
         # Check if device has an identifier in our domain

--- a/custom_components/hcu_integration/manifest.json
+++ b/custom_components/hcu_integration/manifest.json
@@ -12,7 +12,7 @@
   "requirements": [
     "aiohttp>=3.0.0"
   ],
-  "version": "1.19.0",
+  "version": "1.19.1",
   "dependencies": [],
   "reconfigure": true,
   "platforms": [

--- a/tests/mock_hass/homeassistant/const.py
+++ b/tests/mock_hass/homeassistant/const.py
@@ -1,4 +1,6 @@
-class Platform:
+from enum import Enum
+
+class Platform(Enum):
     COVER = "cover"
     BINARY_SENSOR = "binary_sensor"
     SENSOR = "sensor"
@@ -11,7 +13,6 @@ class Platform:
     EVENT = "event"
     LOCK = "lock"
     SIREN = "siren"
-    # Add others as needed
 
 CONF_HOST = "host"
 CONF_TOKEN = "token"


### PR DESCRIPTION
…and orphaned devices

This commit improves the entity discovery process by adding a global cleanup step. It compares the devices currently present in the HCU API state against the Home Assistant device registry. Any device in the registry that is no longer valid (e.g., zombie groups, removed devices) is now explicitly removed. Also fixes a bug in HcuCoordinator where config_entry was not properly assigned.