### PR TITLE
Fix #163 HmIP-STV

### DIFF
--- a/custom_components/hcu_integration/const.py
+++ b/custom_components/hcu_integration/const.py
@@ -547,6 +547,7 @@ HMIP_FEATURE_TO_ENTITY = {
         "class": "HcuGenericSensor",
         "name": "Absolute Angle",
         "icon": "mdi:angle-acute",
+        "unit": DEGREE,
         "state_class": SensorStateClass.MEASUREMENT,
         "entity_registry_enabled_default": False,
     },


### PR DESCRIPTION
#163 

**Changelog**

Removed accelerationSensorMode from the integration logic, as it represents a configuration value rather than a runtime state.

Added the following entities to expose triggering and state information:
accelerationSensorTriggered
tiltState
absoluteAngle
to HmIP-STV