### PR TITLE
Add HmIP-FDC support with Access Authorization & per-device PIN

### DIFF
--- a/custom_components/hcu_integration/__init__.py
+++ b/custom_components/hcu_integration/__init__.py
@@ -50,6 +50,9 @@ type HcuData = dict[str, "HcuCoordinator"]
 
 SERVICE_ENTRIES_KEY = f"{DOMAIN}_service_entries"
 
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:
+    """Set up the HCU component."""
+    return True
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Homematic IP Local (HCU) from a config entry."""
@@ -69,7 +72,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     domain_data = cast(HcuData, hass.data.setdefault(DOMAIN, {}))
     domain_data[entry.entry_id] = coordinator
-
     if not await coordinator.async_setup():
         return False
 

--- a/custom_components/hcu_integration/api.py
+++ b/custom_components/hcu_integration/api.py
@@ -281,7 +281,7 @@ class HcuApiClient:
                     "CONFIG_TEMPLATE_REQUEST": self._send_config_template_response,
                     "CONFIG_UPDATE_REQUEST": self._send_config_update_response,
                 }
-            asyncio.create_task(handler_map[msg_type](msg_id))
+                asyncio.create_task(handler_map[msg_type](msg_id))
         elif self._event_callback:
             self._event_callback(msg)
 

--- a/custom_components/hcu_integration/button.py
+++ b/custom_components/hcu_integration/button.py
@@ -17,6 +17,7 @@ from .api import HcuApiClient, HcuApiError
 from .util import handle_lock_api_error
 from .const import (
     CONF_PIN,
+    CONF_CLIENT_ID,
     LOCK_STATE_OPEN,
 )
 
@@ -136,17 +137,31 @@ class HcuDoorPullLatchButton(HcuBaseEntity, ButtonEntity):
 
         # Find the matching ACCESS_AUTHORIZATION_CHANNEL for this DOOR_SWITCH_CHANNEL.
         # The authorization channel shares the same groupIndex as the switch channel.
-        self._authorization_channel_index: int | None = self._find_authorization_channel()
+        result = self._find_authorization_channel()
+        if result is not None:
+            self._authorization_channel_index, self._authorization_profile_label = result
+        else:
+            self._authorization_channel_index = None
+            self._authorization_profile_label = None
+        _LOGGER.debug(
+                "debug: %s, %s", self._authorization_channel_index, self._authorization_profile_label
+            )
 
-    def _find_authorization_channel(self) -> int | None:
+    def _find_authorization_channel(self) -> tuple[int, str] | None:
         """Find the ACCESS_AUTHORIZATION_CHANNEL index that belongs to this switch channel."""
+        client_id = self._config_entry.data.get(CONF_CLIENT_ID)
+        if not client_id:
+            _LOGGER.error(
+                "No clientId found for this integration. "
+                "Please go to Settings → Integrations → Homematic IP HCU → Configure"
+                "and re-authorize the integration.",
+            )
+            return None
+
         channels = self._device.get("functionalChannels", {})
-        _LOGGER.debug("channels type: %s", type(channels))
-        _LOGGER.debug("channels value: %s", channels)
         switch_group_index = self._channel.get("groupIndex")
 
-        # Collect all ACCESS_AUTHORIZATION_CHANNEL candidates with matching groupIndex
-        candidates: list[tuple[int, list[str]]] = []  # (channel_index, group_ids)
+        candidates: list[tuple[int, list[str]]] = []
         for ch_idx, ch_data in channels.items():
             if (
                 ch_data.get("functionalChannelType") == "ACCESS_AUTHORIZATION_CHANNEL"
@@ -157,43 +172,66 @@ class HcuDoorPullLatchButton(HcuBaseEntity, ButtonEntity):
         if not candidates:
             return None
 
-        # Filter: only keep channels that are referenced by an ACCESS_AUTHORIZATION_PROFILE group
-        profiled: list[tuple[int, str]] = []  # (channel_index, profile_label)
+        profiled: list[tuple[int, str]] = []
+        client_authorized = False
         for ch_idx, group_ids in candidates:
             for group_id in group_ids:
                 group = self._client.get_group_by_id(str(group_id)) or {}
-                if group.get("type") == "ACCESS_AUTHORIZATION_PROFILE":
-                    label = group.get("label", "")
-                    profiled.append((ch_idx, label))
+                if (
+                    group.get("type") == "ACCESS_AUTHORIZATION_PROFILE"
+                ):
+                    authorized_clients = group.get("clientIds", [])
+                    if client_id in authorized_clients:
+                        client_authorized = True
+                        profiled.append((ch_idx, group.get("label", "")))
 
-        if not profiled:
-            # No profile assigned at all, fall back to first candidate
-            return candidates[0][0]
+        if not client_authorized:
+            _LOGGER.error(
+                "The Home Assistant Integration is not authorized to control device '%s' channel %s. "
+                "Please open the Homematic IP app, go to → More → Access authorisations, "
+                "add the 'Home Assistant Integration' user to the authorisation profile, "
+                "then reload the integration in Home Assistant.",
+                self._device_id,
+                self._channel_index,
+            )
+            return None
 
-        if len(profiled) == 1:
-            return profiled[0][0]
+        if len(profiled) > 1:
+            _LOGGER.warning(
+                "Multiple ACCESS_AUTHORIZATION_PROFILEs found for %s channel %s. "
+                "Using first match.",
+                self._device_id,
+                self._channel_index,
+            )
 
-        # Multiple profiles → find the one labeled "homeassistant"
-        for ch_idx, label in profiled:
-            normalized = label.lower().replace(" ", "")
-            if "homeassistant" in normalized:
-                return ch_idx
-
-        # No "homeassistant" label found → log warning and return first
-        _LOGGER.warning(
-            "Multiple ACCESS_AUTHORIZATION_PROFILEs found for %s channel %s, "
-            "but none is labeled 'homeassistant'. Using first match. "
-            "Profiles: %s",
-            self._device_id,
-            self._channel_index,
-            [(idx, lbl) for idx, lbl in profiled],
-        )
-        return profiled[0][0]
+        return profiled[0]
     
     async def async_press(self) -> None:
         """Pull the door latch."""
         pin = self._config_entry.data.get(CONF_PIN)
-        _LOGGER.info("Triggering pull latch for %s", self.entity_id)
+        client_id = self._config_entry.data.get(CONF_CLIENT_ID)
+        
+        if not client_id:
+            _LOGGER.error(
+                "No clientId found for this integration. "
+                "Please go to Settings → Integrations → Homematic IP HCU → Configure"
+                "and re-authorize the integration.",
+            )
+            return
+            
+        if self._authorization_channel_index is None: 
+            _LOGGER.error(
+                "The Home Assistant Integration is not authorized to control device '%s' channel %s. "
+                "Please open the Homematic IP app, go to → More → Access authorisations, "
+                "add the 'Home Assistant Integration' user to the authorisation profile, "
+                "then reload the integration in Home Assistant. %s",
+                self._device_id,
+                self._channel_index,
+                client_id,
+            )
+            return
+            
+        _LOGGER.debug("Triggering pull latch for %s with ACCESS_AUTHORIZATION_PROFILE %s", self.entity_id, self._authorization_profile_label)
         try:
             await self._client.async_pull_latch(
                 self._device_id, self._authorization_channel_index, pin=pin

--- a/custom_components/hcu_integration/button.py
+++ b/custom_components/hcu_integration/button.py
@@ -181,7 +181,7 @@ class HcuDoorPullLatchButton(HcuBaseEntity, ButtonEntity):
                 ch_data.get("functionalChannelType") == "ACCESS_AUTHORIZATION_CHANNEL"
                 and ch_data.get("groupIndex") == switch_group_index
             ):
-                candidates.append((int(ch_idx), list(ch_data.get("groups", []))))
+                candidates.append((int(ch_idx), list(ch_data.get("groups") or [])))
 
         if not candidates:
             return None

--- a/custom_components/hcu_integration/button.py
+++ b/custom_components/hcu_integration/button.py
@@ -138,8 +138,6 @@ class HcuDoorPullLatchButton(HcuBaseEntity, ButtonEntity):
         self._set_entity_name(channel_label=self._channel.get("label"), feature_name="Pull Latch")
         self._attr_unique_id = f"{self._device_id}_{self._channel_index}_pull_latch"
 
-        channels = self._device.get("functionalChannels", {})
-        switch_group_index = self._channel.get("groupIndex")
         self._authorization_channel_index = None
         self._authorization_profile_label = None
     
@@ -195,7 +193,7 @@ class HcuDoorPullLatchButton(HcuBaseEntity, ButtonEntity):
                 group = self._client.get_group_by_id(str(group_id)) or {}
                 if (
                     group.get("type") == "ACCESS_AUTHORIZATION_PROFILE"
-                    and group.get("authorizationPinAssigned") is True  # ← hier
+                    and group.get("authorizationPinAssigned") is True
                 ):
                     authorized_clients = group.get("clientIds", [])
                     if client_id in authorized_clients:
@@ -288,21 +286,20 @@ class HcuDoorPullLatchButton(HcuBaseEntity, ButtonEntity):
         except HcuApiError as err:
             err_type = handle_lock_api_error(err, self.name, pin)
             if err_type == "invalid_pin" and pin:
-                if err_type == "invalid_pin" and pin:
-                    ir.async_create_issue(
-                        hass=self.hass,
-                        domain=DOMAIN,
-                        issue_id=f"pin_failed_{self._device_id}",
-                        is_fixable=True,
-                        severity=ir.IssueSeverity.ERROR,
-                        translation_key="pin_failed",
-                        data={
-                            "entry_id": self._config_entry.entry_id,
-                            "device_name": self.name,
-                        },
-                        translation_placeholders={"device_name": self.name},
-                    )
-            
+                ir.async_create_issue(
+                    hass=self.hass,
+                    domain=DOMAIN,
+                    issue_id=f"pin_failed_{self._device_id}",
+                    is_fixable=True,
+                    severity=ir.IssueSeverity.ERROR,
+                    translation_key="pin_failed",
+                    data={
+                        "entry_id": self._config_entry.entry_id,
+                        "device_name": self.name,
+                    },
+                    translation_placeholders={"device_name": self.name},
+                )
+        
             if not err_type:
                 _LOGGER.error(
                     "Error triggering pull latch for %s: %s", self.name, err

--- a/custom_components/hcu_integration/button.py
+++ b/custom_components/hcu_integration/button.py
@@ -149,7 +149,20 @@ class HcuDoorPullLatchButton(HcuBaseEntity, ButtonEntity):
         result = self._find_authorization_channel()
         if result is not None:
             self._authorization_channel_index, self._authorization_profile_label = result
-            
+    
+    def _get_pin(self) -> str | None:
+        """First device specified PIN, then global PIN as fallback."""
+        config_entry = self.coordinator.config_entry
+        pins = config_entry.options.get(CONF_PULL_LATCH_PINS, {})
+        if code := pins.get(self._attr_unique_id):
+            _LOGGER.debug("Device '%s': using specified device pin", self.name)
+            return code
+        if global_pin := config_entry.data.get(CONF_PIN):
+            _LOGGER.debug("Device '%s': using global PIN from config entry", self.name)
+            return global_pin
+        _LOGGER.debug("Device '%s': no PIN available", self.name)
+        return None
+        
     def _find_authorization_channel(self) -> tuple[int, str] | None:
         """Find the ACCESS_AUTHORIZATION_CHANNEL index that belongs to this switch channel."""
         client_id = self._config_entry.data.get(CONF_CLIENT_ID)
@@ -220,8 +233,7 @@ class HcuDoorPullLatchButton(HcuBaseEntity, ButtonEntity):
     
     async def async_press(self) -> None:
         """Pull the door latch."""
-        pins = self._config_entry.options.get(CONF_PULL_LATCH_PINS, {})
-        pin = pins.get(self._attr_unique_id) or self._config_entry.data.get(CONF_PIN)
+        pin = self._get_pin()
         
         client_id = self._config_entry.data.get(CONF_CLIENT_ID)
         
@@ -392,10 +404,23 @@ class HcuDoorUnlatchButton(HcuBaseEntity, ButtonEntity):
         self._config_entry = coordinator.config_entry
         self._set_entity_name(channel_label=self._channel.get("label"), feature_name="Unlatch")
         self._attr_unique_id = f"{self._device_id}_{self._channel_index}_unlatch"
-
+    
+    def _get_pin_from_lock(self) -> str | None:
+        """Get PIN from associated lock entity, then global PIN as fallback."""
+        for lock in self.coordinator.entities.get(Platform.LOCK, []):
+            if lock._device_id == self._device_id and lock._channel_index == self._channel_index:
+                if pin := lock._get_pin():
+                    _LOGGER.debug("Device '%s': using PIN from associated lock", self.name)
+                    return pin
+        if global_pin := self._config_entry.data.get(CONF_PIN):
+            _LOGGER.debug("Device '%s': using global PIN from config entry", self.name)
+            return global_pin
+        _LOGGER.debug("Device '%s': no PIN available", self.name)
+        return None
+    
     async def async_press(self) -> None:
         """Pull the door latch to open the door."""
-        pin = self._config_entry.data.get(CONF_PIN)
+        pin = self._get_pin_from_lock()
         _LOGGER.info("Triggering unlatch for %s", self.name)
         
         try:

--- a/custom_components/hcu_integration/button.py
+++ b/custom_components/hcu_integration/button.py
@@ -18,6 +18,7 @@ from .api import HcuApiClient, HcuApiError
 from .util import handle_lock_api_error
 from .const import (
     CONF_PIN,
+    CONF_PULL_LATCH_PINS,
     CONF_CLIENT_ID,
     DOMAIN,
     LOCK_STATE_OPEN,
@@ -219,7 +220,9 @@ class HcuDoorPullLatchButton(HcuBaseEntity, ButtonEntity):
     
     async def async_press(self) -> None:
         """Pull the door latch."""
-        pin = self._config_entry.data.get(CONF_PIN)
+        pins = self._config_entry.options.get(CONF_PULL_LATCH_PINS, {})
+        pin = pins.get(self._attr_unique_id) or self._config_entry.data.get(CONF_PIN)
+        
         client_id = self._config_entry.data.get(CONF_CLIENT_ID)
         
         if not client_id:

--- a/custom_components/hcu_integration/button.py
+++ b/custom_components/hcu_integration/button.py
@@ -113,7 +113,6 @@ class HcuResetWaterVolume(HcuBaseEntity, ButtonEntity):
                 "Error resetting water volume for %s: %s", self.entity_id, err
             )
 
-
 class HcuDoorPullLatchButton(HcuBaseEntity, ButtonEntity):
     """Representation of a button to trigger a door opener (e.g., HmIP-FDC)."""
 
@@ -133,16 +132,71 @@ class HcuDoorPullLatchButton(HcuBaseEntity, ButtonEntity):
         self._config_entry = coordinator.config_entry
         # Set entity name using the centralized naming helper
         self._set_entity_name(channel_label=self._channel.get("label"), feature_name="Pull Latch")
-
         self._attr_unique_id = f"{self._device_id}_{self._channel_index}_pull_latch"
 
+        # Find the matching ACCESS_AUTHORIZATION_CHANNEL for this DOOR_SWITCH_CHANNEL.
+        # The authorization channel shares the same groupIndex as the switch channel.
+        self._authorization_channel_index: int | None = self._find_authorization_channel()
+
+    def _find_authorization_channel(self) -> int | None:
+        """Find the ACCESS_AUTHORIZATION_CHANNEL index that belongs to this switch channel."""
+        channels = self._device.get("functionalChannels", {})
+        _LOGGER.debug("channels type: %s", type(channels))
+        _LOGGER.debug("channels value: %s", channels)
+        switch_group_index = self._channel.get("groupIndex")
+
+        # Collect all ACCESS_AUTHORIZATION_CHANNEL candidates with matching groupIndex
+        candidates: list[tuple[int, list[str]]] = []  # (channel_index, group_ids)
+        for ch_idx, ch_data in channels.items():
+            if (
+                ch_data.get("functionalChannelType") == "ACCESS_AUTHORIZATION_CHANNEL"
+                and ch_data.get("groupIndex") == switch_group_index
+            ):
+                candidates.append((int(ch_idx), list(ch_data.get("groups", []))))
+
+        if not candidates:
+            return None
+
+        # Filter: only keep channels that are referenced by an ACCESS_AUTHORIZATION_PROFILE group
+        profiled: list[tuple[int, str]] = []  # (channel_index, profile_label)
+        for ch_idx, group_ids in candidates:
+            for group_id in group_ids:
+                group = self._client.get_group_by_id(str(group_id)) or {}
+                if group.get("type") == "ACCESS_AUTHORIZATION_PROFILE":
+                    label = group.get("label", "")
+                    profiled.append((ch_idx, label))
+
+        if not profiled:
+            # No profile assigned at all, fall back to first candidate
+            return candidates[0][0]
+
+        if len(profiled) == 1:
+            return profiled[0][0]
+
+        # Multiple profiles → find the one labeled "homeassistant"
+        for ch_idx, label in profiled:
+            normalized = label.lower().replace(" ", "")
+            if "homeassistant" in normalized:
+                return ch_idx
+
+        # No "homeassistant" label found → log warning and return first
+        _LOGGER.warning(
+            "Multiple ACCESS_AUTHORIZATION_PROFILEs found for %s channel %s, "
+            "but none is labeled 'homeassistant'. Using first match. "
+            "Profiles: %s",
+            self._device_id,
+            self._channel_index,
+            [(idx, lbl) for idx, lbl in profiled],
+        )
+        return profiled[0][0]
+    
     async def async_press(self) -> None:
         """Pull the door latch."""
         pin = self._config_entry.data.get(CONF_PIN)
         _LOGGER.info("Triggering pull latch for %s", self.entity_id)
         try:
             await self._client.async_pull_latch(
-                self._device_id, self._channel_index, pin=pin
+                self._device_id, self._authorization_channel_index, pin=pin
             )
         except HcuApiError as err:
             err_type = handle_lock_api_error(err, self.name, pin)

--- a/custom_components/hcu_integration/button.py
+++ b/custom_components/hcu_integration/button.py
@@ -135,18 +135,18 @@ class HcuDoorPullLatchButton(HcuBaseEntity, ButtonEntity):
         self._set_entity_name(channel_label=self._channel.get("label"), feature_name="Pull Latch")
         self._attr_unique_id = f"{self._device_id}_{self._channel_index}_pull_latch"
 
-        # Find the matching ACCESS_AUTHORIZATION_CHANNEL for this DOOR_SWITCH_CHANNEL.
-        # The authorization channel shares the same groupIndex as the switch channel.
+        channels = self._device.get("functionalChannels", {})
+        switch_group_index = self._channel.get("groupIndex")
+        self._authorization_channel_index = None
+        self._authorization_profile_label = None
+    
+    async def async_added_to_hass(self) -> None:
+        """Run when entity is added to HA – now self.hass is available."""
+        await super().async_added_to_hass()
         result = self._find_authorization_channel()
         if result is not None:
             self._authorization_channel_index, self._authorization_profile_label = result
-        else:
-            self._authorization_channel_index = None
-            self._authorization_profile_label = None
-        _LOGGER.debug(
-                "debug: %s, %s", self._authorization_channel_index, self._authorization_profile_label
-            )
-
+            
     def _find_authorization_channel(self) -> tuple[int, str] | None:
         """Find the ACCESS_AUTHORIZATION_CHANNEL index that belongs to this switch channel."""
         client_id = self._config_entry.data.get(CONF_CLIENT_ID)
@@ -224,10 +224,9 @@ class HcuDoorPullLatchButton(HcuBaseEntity, ButtonEntity):
                 "The Home Assistant Integration is not authorized to control device '%s' channel %s. "
                 "Please open the Homematic IP app, go to → More → Access authorisations, "
                 "add the 'Home Assistant Integration' user to the authorisation profile, "
-                "then reload the integration in Home Assistant. %s",
+                "then reload the integration in Home Assistant.",
                 self._device_id,
                 self._channel_index,
-                client_id,
             )
             return
             

--- a/custom_components/hcu_integration/button.py
+++ b/custom_components/hcu_integration/button.py
@@ -10,6 +10,7 @@ from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .entity import HcuBaseEntity
@@ -18,6 +19,7 @@ from .util import handle_lock_api_error
 from .const import (
     CONF_PIN,
     CONF_CLIENT_ID,
+    DOMAIN,
     LOCK_STATE_OPEN,
 )
 
@@ -179,6 +181,7 @@ class HcuDoorPullLatchButton(HcuBaseEntity, ButtonEntity):
                 group = self._client.get_group_by_id(str(group_id)) or {}
                 if (
                     group.get("type") == "ACCESS_AUTHORIZATION_PROFILE"
+                    and group.get("authorizationPinAssigned") is True  # ← hier
                 ):
                     authorized_clients = group.get("clientIds", [])
                     if client_id in authorized_clients:
@@ -188,13 +191,21 @@ class HcuDoorPullLatchButton(HcuBaseEntity, ButtonEntity):
         if not client_authorized:
             _LOGGER.error(
                 "The Home Assistant Integration is not authorized to control device '%s' channel %s. "
+                "Either the integration is not added to an Access Authorization Profile, "
+                "or no PIN is stored in the profile. "
                 "Please open the Homematic IP app, go to → More → Access authorisations, "
-                "add the 'Home Assistant Integration' user to the authorisation profile, "
+                "add the 'Home Assistant Integration' user to the authorisation profile and ensure a PIN is set, "
                 "then reload the integration in Home Assistant.",
                 self._device_id,
                 self._channel_index,
             )
             return None
+        
+        ir.async_delete_issue(
+            hass=self.hass,
+            domain=DOMAIN,
+            issue_id=f"access_authorization_{self._device_id}_{self._channel_index}",
+        )    
 
         if len(profiled) > 1:
             _LOGGER.warning(
@@ -222,13 +233,37 @@ class HcuDoorPullLatchButton(HcuBaseEntity, ButtonEntity):
         if self._authorization_channel_index is None: 
             _LOGGER.error(
                 "The Home Assistant Integration is not authorized to control device '%s' channel %s. "
+                "Either the integration is not added to an Access Authorization Profile, "
+                "or no PIN is stored in the profile. "
                 "Please open the Homematic IP app, go to → More → Access authorisations, "
-                "add the 'Home Assistant Integration' user to the authorisation profile, "
+                "add the 'Home Assistant Integration' user to the authorisation profile and ensure a PIN is set, "
                 "then reload the integration in Home Assistant.",
                 self._device_id,
                 self._channel_index,
             )
+            ir.async_create_issue(
+                hass=self.hass,
+                domain=DOMAIN,
+                issue_id=f"access_authorization_{self._device_id}_{self._channel_index}",
+                is_fixable=True,
+                severity=ir.IssueSeverity.ERROR,
+                translation_key="access_authorization",
+                translation_placeholders={
+                    "device_name": self._device.get("label", self._device_id),
+                    "channel_index": str(self._channel_index),
+                },
+                data={
+                    "device_name": self._device.get("label", self._device_id),
+                    "channel_index": self._channel_index,
+                },
+            )
             return
+
+        ir.async_delete_issue(
+            hass=self.hass,
+            domain=DOMAIN,
+            issue_id=f"access_authorization_{self._device_id}_{self._channel_index}",
+        )        
             
         _LOGGER.debug("Triggering pull latch for %s with ACCESS_AUTHORIZATION_PROFILE %s", self.entity_id, self._authorization_profile_label)
         try:
@@ -238,7 +273,20 @@ class HcuDoorPullLatchButton(HcuBaseEntity, ButtonEntity):
         except HcuApiError as err:
             err_type = handle_lock_api_error(err, self.name, pin)
             if err_type == "invalid_pin" and pin:
-                self._config_entry.async_start_reauth(self.hass)
+                if err_type == "invalid_pin" and pin:
+                    ir.async_create_issue(
+                        hass=self.hass,
+                        domain=DOMAIN,
+                        issue_id=f"pin_failed_{self._device_id}",
+                        is_fixable=True,
+                        severity=ir.IssueSeverity.ERROR,
+                        translation_key="pin_failed",
+                        data={
+                            "entry_id": self._config_entry.entry_id,
+                            "device_name": self.name,
+                        },
+                        translation_placeholders={"device_name": self.name},
+                    )
             
             if not err_type:
                 _LOGGER.error(
@@ -354,7 +402,19 @@ class HcuDoorUnlatchButton(HcuBaseEntity, ButtonEntity):
         except HcuApiError as err:
             err_type = handle_lock_api_error(err, self.name, pin)
             if err_type == "invalid_pin" and pin:
-                self._config_entry.async_start_reauth(self.hass)
+                ir.async_create_issue(
+                    hass=self.hass,
+                    domain=DOMAIN,
+                    issue_id=f"pin_failed_{self._device_id}",
+                    is_fixable=True,
+                    severity=ir.IssueSeverity.ERROR,
+                    translation_key="pin_failed",
+                    data={
+                        "entry_id": self._config_entry.entry_id,
+                        "device_name": self.name,
+                    },
+                    translation_placeholders={"device_name": self.name},
+                )
             
             if not err_type:
                 _LOGGER.error(

--- a/custom_components/hcu_integration/config_flow.py
+++ b/custom_components/hcu_integration/config_flow.py
@@ -44,6 +44,7 @@ from .const import (
     CONF_COMFORT_TEMPERATURE,
     DEFAULT_COMFORT_TEMPERATURE,
     CONF_AUTH_PORT,
+    CONF_CLIENT_ID,
     CONF_WEBSOCKET_PORT,
     CONF_ENTITY_PREFIX,
     CONF_PLATFORM_OVERRIDES,
@@ -159,6 +160,7 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
         errors = {}
         host = self._config_data["host"]
         auth_port = self._config_data["auth_port"]
+        
 
         if user_input is not None:
             activation_key = user_input["activation_key"]
@@ -169,7 +171,7 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
                 auth_token = await self._async_get_auth_token(
                     session, host, auth_port, activation_key, ssl_context
                 )
-                await self._async_confirm_auth_token(
+                client_id = await self._async_confirm_auth_token(
                     session, host, auth_port, activation_key, auth_token, ssl_context
                 )
 
@@ -180,6 +182,7 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
 
                 # Save token and prefix to config data
                 self._config_data[CONF_TOKEN] = auth_token
+                self._config_data[CONF_CLIENT_ID] = client_id
                 
                 # Add entity prefix if provided
                 if prefix := self._config_data.get(CONF_ENTITY_PREFIX, "").strip():
@@ -431,7 +434,7 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
         key: str,
         token: str,
         ssl_context,
-    ) -> None:
+    ) -> str:
         """Confirm the new auth token with the HCU."""
         url = f"https://{host}:{port}/hmip/auth/confirmConnectApiAuthToken"
         headers = {"VERSION": "12"}
@@ -441,8 +444,10 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
             url, headers=headers, json=body, ssl=ssl_context
         ) as response:
             response.raise_for_status()
-            if not (await response.json()).get("clientId"):
+            data = await response.json()
+            if not (client_id := data.get("clientId")):
                 raise ValueError("HCU did not confirm the authToken.")
+            return client_id
 
 class HcuOptionsFlowHandler(OptionsFlow):
     """Handle an options flow for the HCU integration."""

--- a/custom_components/hcu_integration/config_flow.py
+++ b/custom_components/hcu_integration/config_flow.py
@@ -322,64 +322,19 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Handle a reconfiguration flow for changing HCU connection details."""
+        """Handle reconfiguration – step 1: host and ports."""
         entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
         errors = {}
-
+    
         if user_input is not None:
-            new_host = user_input[CONF_HOST]
-            new_auth_port = user_input[CONF_AUTH_PORT]
-            new_websocket_port = user_input[CONF_WEBSOCKET_PORT]
-
-            listener_task = None
-            client = None
-            try:
-                session = aiohttp_client.async_get_clientsession(self.hass)
-                client = HcuApiClient(
-                    self.hass,
-                    new_host,
-                    entry.data[CONF_TOKEN],
-                    session,
-                    new_auth_port,
-                    new_websocket_port,
-                )
-
-                await client.connect()
-                listener_task = self.hass.async_create_task(client.listen())
-                await client.get_system_state()
-
-                self.hass.config_entries.async_update_entry(
-                    entry,
-                    data={
-                        **entry.data,
-                        CONF_HOST: new_host,
-                        CONF_AUTH_PORT: new_auth_port,
-                        CONF_WEBSOCKET_PORT: new_websocket_port,
-                    },
-                )
-                await self.hass.config_entries.async_reload(entry.entry_id)
-                return self.async_abort(reason="reconfigure_successful")
-
-            except (
-                HcuApiError,
-                ConnectionError,
-                asyncio.TimeoutError,
-                aiohttp.ClientError,
-            ):
-                _LOGGER.error("Failed to connect to new HCU host/port combination")
-                errors["base"] = "cannot_connect"
-            except ValueError as err:
-                _LOGGER.error("Invalid configuration or response: %s", err)
-                errors["base"] = "invalid_config"
-            except Exception:
-                _LOGGER.exception("Unexpected error during reconfiguration.")
-                errors["base"] = "unknown"
-            finally:
-                if listener_task:
-                    listener_task.cancel()
-                if client and client.is_connected:
-                    await client.disconnect()
-
+            self._config_data = {
+                **entry.data,
+                CONF_HOST: user_input[CONF_HOST],
+                CONF_AUTH_PORT: user_input[CONF_AUTH_PORT],
+                CONF_WEBSOCKET_PORT: user_input[CONF_WEBSOCKET_PORT],
+            }
+            return await self.async_step_reconfigure_auth()
+    
         return self.async_show_form(
             step_id="reconfigure",
             data_schema=vol.Schema(
@@ -397,6 +352,78 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
                     ): int,
                 }
             ),
+            errors=errors,
+        )
+    
+    
+    async def async_step_reconfigure_auth(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle reconfiguration – step 2: activation key and token renewal."""
+        errors = {}
+        host = self._config_data[CONF_HOST]
+        auth_port = self._config_data[CONF_AUTH_PORT]
+    
+        if user_input is not None:
+            activation_key = user_input["activation_key"]
+            session = aiohttp_client.async_get_clientsession(self.hass)
+            ssl_context = await create_unverified_ssl_context(self.hass)
+    
+            listener_task = None
+            client = None
+            try:
+                new_token = await self._async_get_auth_token(
+                    session, host, auth_port, activation_key, ssl_context
+                )
+                new_client_id = await self._async_confirm_auth_token(
+                    session, host, auth_port, activation_key, new_token, ssl_context
+                )
+    
+                # Verify connection with new credentials
+                client = HcuApiClient(
+                    self.hass,
+                    host,
+                    new_token,
+                    session,
+                    self._config_data[CONF_AUTH_PORT],
+                    self._config_data[CONF_WEBSOCKET_PORT],
+                )
+                await client.connect()
+                listener_task = self.hass.async_create_task(client.listen())
+                await client.get_system_state()
+    
+                entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+                self.hass.config_entries.async_update_entry(
+                    entry,
+                    data={
+                        **entry.data,
+                        CONF_HOST: self._config_data[CONF_HOST],
+                        CONF_AUTH_PORT: self._config_data[CONF_AUTH_PORT],
+                        CONF_WEBSOCKET_PORT: self._config_data[CONF_WEBSOCKET_PORT],
+                        CONF_TOKEN: new_token,
+                        CONF_CLIENT_ID: new_client_id,
+                    },
+                )
+                await self.hass.config_entries.async_reload(entry.entry_id)
+                return self.async_abort(reason="reconfigure_successful")
+    
+            except (aiohttp.ClientError, asyncio.TimeoutError):
+                errors["base"] = "cannot_connect"
+            except ValueError:
+                errors["base"] = "invalid_key"
+            except Exception:
+                _LOGGER.exception("Unexpected error during reconfiguration.")
+                errors["base"] = "unknown"
+            finally:
+                if listener_task:
+                    listener_task.cancel()
+                if client and client.is_connected:
+                    await client.disconnect()
+    
+        return self.async_show_form(
+            step_id="reconfigure_auth",
+            data_schema=vol.Schema({vol.Required("activation_key"): str}),
+            description_placeholders={"hcu_ip": host},
             errors=errors,
         )
 

--- a/custom_components/hcu_integration/config_flow.py
+++ b/custom_components/hcu_integration/config_flow.py
@@ -66,12 +66,6 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-
-async def async_setup(hass: HomeAssistant, config: dict):
-    """Set up the HCU component."""
-    return True
-
-
 async def async_will_remove_config_entry(
     hass: HomeAssistant, config_entry: ConfigEntry
 ) -> None:
@@ -111,7 +105,11 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
     VERSION = 1
     reauth_entry: ConfigEntry | None = None
 
-    _config_data: dict[str, Any] = {}
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        super().__init__()
+        self._config_data: dict[str, Any] = {}
+
 
     @staticmethod
     @callback
@@ -158,10 +156,9 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Handle the authentication step where the user provides an activation key."""
         errors = {}
-        host = self._config_data["host"]
+        host = self._config_data.get("host", "HOST_NOT_FOUND")
         auth_port = self._config_data["auth_port"]
         
-
         if user_input is not None:
             activation_key = user_input["activation_key"]
             session = aiohttp_client.async_get_clientsession(self.hass)
@@ -297,27 +294,7 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
         self.reauth_entry = self.hass.config_entries.async_get_entry(
             self.context["entry_id"]
         )
-        return await self.async_step_reauth_confirm()
-
-    async def async_step_reauth_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Handle the PIN reauthentication form."""
-        if user_input is not None and self.reauth_entry:
-            new_data = {**self.reauth_entry.data, CONF_PIN: user_input[CONF_PIN]}
-            self.hass.config_entries.async_update_entry(
-                self.reauth_entry, data=new_data
-            )
-            await self.hass.config_entries.async_reload(self.reauth_entry.entry_id)
-            return self.async_abort(reason="reauth_successful")
-
-        return self.async_show_form(
-            step_id="reauth_confirm",
-            data_schema=vol.Schema({vol.Required(CONF_PIN): str}),
-            description_placeholders={
-                "info": "Your door lock requires a PIN for operation. Please enter the PIN you configured in your Homematic IP app."
-            },
-        )
+        return await self.async_step_reconfigure()
 
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None
@@ -352,6 +329,7 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
                     ): int,
                 }
             ),
+            description_placeholders={"hcu_ip": entry.data[CONF_HOST]},
             errors=errors,
         )
     

--- a/custom_components/hcu_integration/const.py
+++ b/custom_components/hcu_integration/const.py
@@ -41,6 +41,7 @@ PLATFORMS: list[Platform] = [
     Platform.SENSOR,
     Platform.SIREN,
     Platform.SWITCH,
+    Platform.TEXT,
     Platform.UPDATE,
 ]
 
@@ -56,6 +57,7 @@ PLUGIN_ISSUE_TRACKER_URL = "https://github.com/Ediminator/hacs-homematicip-hcu/i
 
 # --- Configuration Constants ---
 CONF_PIN = "pin"
+CONF_PULL_LATCH_PINS = "pull_latch_pins"
 CONF_AUTH_PORT = "auth_port"
 CONF_WEBSOCKET_PORT = "websocket_port"
 CONF_CLIENT_ID = "client_id"
@@ -1092,7 +1094,7 @@ HMIP_CHANNEL_TYPE_TO_ENTITY = {
     "BLIND_CHANNEL": {"class": "HcuCover"},
     "BRAND_BLIND_CHANNEL": {"class": "HcuCover"},  # For HmIP-HDM1 HunterDouglas blinds
     "SHADING_CHANNEL": {"class": "HcuCover"},  # For HmIP-HDM1 HunterDouglas shading actuators
-    "GARAGE_DOOR_CHANNEL": {"class": "HcuGarageDoorCover"},
+    "GARAGE_DOOR_CHANNEL": {"class": "HcuGarageDoorCover","extra_entities": ["HcuPullLatchPin"]},
     "DOOR_CHANNEL": {"class": "HcuGarageDoorCover"},
     "DOOR_SWITCH_CHANNEL": {"class": "HcuDoorPullLatchButton"},
     "IMPULSE_OUTPUT_CHANNEL": {"class": "HcuDoorImpulseButton"},

--- a/custom_components/hcu_integration/const.py
+++ b/custom_components/hcu_integration/const.py
@@ -58,6 +58,7 @@ PLUGIN_ISSUE_TRACKER_URL = "https://github.com/Ediminator/hacs-homematicip-hcu/i
 CONF_PIN = "pin"
 CONF_AUTH_PORT = "auth_port"
 CONF_WEBSOCKET_PORT = "websocket_port"
+CONF_CLIENT_ID = "client_id"
 CONF_ENTITY_PREFIX = "entity_prefix"
 CONF_PLATFORM_OVERRIDES = "platform_overrides"  # Dict mapping entity unique_id to platform override
 DEFAULT_HCU_AUTH_PORT = 6969

--- a/custom_components/hcu_integration/const.py
+++ b/custom_components/hcu_integration/const.py
@@ -1094,9 +1094,9 @@ HMIP_CHANNEL_TYPE_TO_ENTITY = {
     "BLIND_CHANNEL": {"class": "HcuCover"},
     "BRAND_BLIND_CHANNEL": {"class": "HcuCover"},  # For HmIP-HDM1 HunterDouglas blinds
     "SHADING_CHANNEL": {"class": "HcuCover"},  # For HmIP-HDM1 HunterDouglas shading actuators
-    "GARAGE_DOOR_CHANNEL": {"class": "HcuGarageDoorCover","extra_entities": ["HcuPullLatchPin"]},
+    "GARAGE_DOOR_CHANNEL": {"class": "HcuGarageDoorCover"},
     "DOOR_CHANNEL": {"class": "HcuGarageDoorCover"},
-    "DOOR_SWITCH_CHANNEL": {"class": "HcuDoorPullLatchButton"},
+    "DOOR_SWITCH_CHANNEL": {"class": "HcuDoorPullLatchButton", "extra_entities": ["HcuPullLatchPin"]},
     "IMPULSE_OUTPUT_CHANNEL": {"class": "HcuDoorImpulseButton"},
     "DOOR_LOCK_CHANNEL": {"class": "HcuLock", "extra_entities": ["HcuDoorUnlatchButton"]},
     "DOOR_LOCK_PRO_CHANNEL": {"class": "HcuLock", "extra_entities": ["HcuDoorUnlatchButton"]},

--- a/custom_components/hcu_integration/diagnostics.py
+++ b/custom_components/hcu_integration/diagnostics.py
@@ -37,7 +37,6 @@ TO_REDACT_HA: set[str] = set()
 
 def _redact_data(data: Any, keys_to_redact: set[str]) -> Any:
     """Recursively redact sensitive data in a dictionary or list."""
-    return data
     if isinstance(data, dict):
         redacted = data.copy()
         for key, value in redacted.items():

--- a/custom_components/hcu_integration/diagnostics.py
+++ b/custom_components/hcu_integration/diagnostics.py
@@ -37,6 +37,7 @@ TO_REDACT_HA: set[str] = set()
 
 def _redact_data(data: Any, keys_to_redact: set[str]) -> Any:
     """Recursively redact sensitive data in a dictionary or list."""
+    return data
     if isinstance(data, dict):
         redacted = data.copy()
         for key, value in redacted.items():

--- a/custom_components/hcu_integration/discovery.py
+++ b/custom_components/hcu_integration/discovery.py
@@ -25,6 +25,7 @@ from . import (
     sensor,
     siren,
     switch,
+    text,
     update,
 )
 from .api import HcuApiClient
@@ -91,6 +92,7 @@ async def async_discover_entities(
         "HcuDoorPullLatchButton": button,
         "HcuDoorImpulseButton": button,
         "HcuDoorUnlatchButton": button,
+        "HcuPullLatchPin": text,
         "HcuDeviceIdentifyButton": button,
         "HcuGenericSensor": sensor,
         "HcuTemperatureSensor": sensor,

--- a/custom_components/hcu_integration/entity.py
+++ b/custom_components/hcu_integration/entity.py
@@ -173,12 +173,6 @@ class HcuBaseEntity(CoordinatorEntity["HcuCoordinator"], HcuEntityPrefixMixin, E
         """Return the latest parent device data from the client's state cache."""
         return self._client.get_device_by_address(self._device_id) or {}
 
-    def _get_pin(self) -> str | None:
-        """Return Global or device spezificed PIN"""
-        config_entry = self.coordinator.config_entry
-        pins = config_entry.options.get(CONF_PULL_LATCH_PINS, {})
-        return pins.get(self._attr_unique_id) or config_entry.data.get(CONF_PIN)
-    
     @property
     def _channel(self) -> dict[str, Any]:
         """Return the latest channel data from the parent device's data structure."""

--- a/custom_components/hcu_integration/entity.py
+++ b/custom_components/hcu_integration/entity.py
@@ -8,7 +8,7 @@ from homeassistant.helpers.entity import DeviceInfo, Entity
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, CONF_ENTITY_PREFIX, HOMEMATIC_MODEL_PREFIXES, CONF_ADVANCED_ATTRIBUTES
+from .const import DOMAIN, CONF_ENTITY_PREFIX, HOMEMATIC_MODEL_PREFIXES, CONF_ADVANCED_ATTRIBUTES, CONF_PIN, CONF_PULL_LATCH_PINS
 from .api import HcuApiClient, HcuApiError
 from .util import get_device_manufacturer
 
@@ -173,6 +173,12 @@ class HcuBaseEntity(CoordinatorEntity["HcuCoordinator"], HcuEntityPrefixMixin, E
         """Return the latest parent device data from the client's state cache."""
         return self._client.get_device_by_address(self._device_id) or {}
 
+    def _get_pin(self) -> str | None:
+        """Return Global or device spezificed PIN"""
+        config_entry = self.coordinator.config_entry
+        pins = config_entry.options.get(CONF_PULL_LATCH_PINS, {})
+        return pins.get(self._attr_unique_id) or config_entry.data.get(CONF_PIN)
+    
     @property
     def _channel(self) -> dict[str, Any]:
         """Return the latest channel data from the parent device's data structure."""

--- a/custom_components/hcu_integration/lock.py
+++ b/custom_components/hcu_integration/lock.py
@@ -1,16 +1,17 @@
 # custom_components/hcu_integration/lock.py
 import logging
 from typing import TYPE_CHECKING
-import json
 
-from homeassistant.components.lock import LockEntity, LockEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.components.lock import LockEntity, LockEntityFeature, ATTR_CODE
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
     CONF_PIN,
+    DOMAIN,
     LOCK_STATE_LOCKED,
     LOCK_STATE_UNLOCKED,
     LOCK_STATE_OPEN,
@@ -49,7 +50,8 @@ class HcuLock(HcuBaseEntity, LockEntity):
 
     PLATFORM = Platform.LOCK
     _attr_supported_features = LockEntityFeature.OPEN
-
+    _attr_code_format = r"^\d+$"
+    
     def __init__(
         self,
         coordinator: "HcuCoordinator",
@@ -174,10 +176,20 @@ class HcuLock(HcuBaseEntity, LockEntity):
             attrs["authorized_access_channels"] = authorized_channels
 
         return attrs
+    
+    def _get_pin(self, kwargs: dict) -> str | None:
+        """First Entity-Code, then global PIN as fallback."""
+        if code := kwargs.get(ATTR_CODE):
+            _LOGGER.debug("Lock '%s': using entity code from service call", self.name)
+            return code
+        if global_pin := self._config_entry.data.get(CONF_PIN):
+            _LOGGER.debug("Lock '%s': using global PIN from config entry", self.name)
+            return global_pin
+        _LOGGER.debug("Lock '%s': no PIN available", self.name)
+        return None
 
-    async def _set_lock_state(self, state: str) -> None:
+    async def _set_lock_state(self, state: str, pin: str | None = None) -> None:
         """Send the command to set the lock state."""
-        pin = self._config_entry.data.get(CONF_PIN)
 
         _LOGGER.debug(
             "Setting lock state for '%s' to %s (channel: %s, device: %s)",
@@ -203,8 +215,19 @@ class HcuLock(HcuBaseEntity, LockEntity):
             
             if err_type == "invalid_pin":
                 self._pin_required = True
-                if pin:
-                    self._config_entry.async_start_reauth(self.hass)
+                ir.async_create_issue(
+                    hass=self.hass,
+                    domain=DOMAIN,
+                    issue_id=f"pin_failed_{self._device_id}",
+                    is_fixable=True,
+                    severity=ir.IssueSeverity.ERROR,
+                    translation_key="pin_failed",
+                    data={
+                        "entry_id": self._config_entry.entry_id,
+                        "device_name": self.name,
+                    },
+                    translation_placeholders={"device_name": self.name},
+                )
             elif not err_type:
                 _LOGGER.error("Failed to set lock state for %s: %s", self.name, err)
 
@@ -221,12 +244,12 @@ class HcuLock(HcuBaseEntity, LockEntity):
 
     async def async_lock(self, **kwargs) -> None:
         """Lock the door."""
-        await self._set_lock_state(LOCK_STATE_LOCKED)
+        await self._set_lock_state(LOCK_STATE_LOCKED, pin=self._get_pin(kwargs))
 
     async def async_unlock(self, **kwargs) -> None:
         """Unlock the door."""
-        await self._set_lock_state(LOCK_STATE_UNLOCKED)
+        await self._set_lock_state(LOCK_STATE_UNLOCKED, pin=self._get_pin(kwargs))
 
     async def async_open(self, **kwargs) -> None:
         """Open the door latch."""
-        await self._set_lock_state(LOCK_STATE_OPEN)
+        await self._set_lock_state(LOCK_STATE_OPEN, pin=self._get_pin(kwargs))

--- a/custom_components/hcu_integration/lock.py
+++ b/custom_components/hcu_integration/lock.py
@@ -1,6 +1,8 @@
 # custom_components/hcu_integration/lock.py
+from __future__ import annotations
+
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform

--- a/custom_components/hcu_integration/repairs.py
+++ b/custom_components/hcu_integration/repairs.py
@@ -1,0 +1,119 @@
+# custom_components/hcu_integration/repairs.py
+"""Repairs for the Homematic IP HCU integration."""
+import logging
+import voluptuous as vol
+
+from homeassistant.components.repairs import RepairsFlow
+from homeassistant.data_entry_flow import FlowResult
+
+from .const import DOMAIN, CONF_PIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class InvalidPinNotificationFlow(RepairsFlow):
+    """Repair flow that only informs about an invalid PIN — no input required."""
+
+    def __init__(self, device_name: str) -> None:
+        """Initialize the notification flow."""
+        self._device_name = device_name
+
+    async def async_step_init(self, user_input=None) -> FlowResult:
+        """Handle the first step."""
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(self, user_input=None) -> FlowResult:
+        """Show the PIN failure notice and confirm."""
+        if user_input is not None:
+            return self.async_create_entry(data={})
+
+        return self.async_show_form(
+            step_id="confirm",
+            description_placeholders={"device_name": self._device_name},
+        )
+
+class AccessAuthorizationRepairFlow(RepairsFlow):
+    """Repair flow for CLIENT_ACCESS_DENIED on a device channel."""
+
+    def __init__(self, device_id: str, channel_index: int) -> None:
+        """Initialize the repair flow."""
+        self._device_id = device_id
+        self._channel_index = channel_index
+
+    async def async_step_init(
+        self, user_input: dict | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the first (and only) step."""
+        if user_input is not None:
+            return self.async_create_entry(data={})
+
+        return self.async_show_form(
+            step_id="init",
+            description_placeholders={
+                "device_id": self._device_id,
+                "channel_index": str(self._channel_index),
+            },
+        )
+
+
+class InvalidPinNotificationFlow(RepairsFlow):
+    """Repair flow that only informs about an invalid PIN — no input required."""
+
+    def __init__(self, hass: HomeAssistant, entry_id: str, device_name: str) -> None:
+        """Initialize the notification flow."""
+        self._hass = hass
+        self._entry_id = entry_id
+        self._device_name = device_name
+
+    async def async_step_init(self, user_input=None) -> FlowResult:
+        """Handle the first step."""
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(self, user_input=None) -> FlowResult:
+        """Show the PIN failure notice and confirm."""
+        if user_input is not None:
+            await self._hass.config_entries.async_reload(self._entry_id)
+            return self.async_create_entry(data={})
+        return self.async_show_form(
+            step_id="confirm",
+            description_placeholders={"device_name": self._device_name},
+        )
+
+class AccessAuthorizationRepairFlow(RepairsFlow):
+    """Repair flow for CLIENT_ACCESS_DENIED on a device channel."""
+
+    def __init__(self, device_name: str, channel_index: int) -> None:
+        """Initialize the repair flow."""
+        self._device_name = device_name
+        self._channel_index = channel_index
+
+    async def async_step_init(self, user_input=None) -> FlowResult:
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(self, user_input=None) -> FlowResult:
+        if user_input is not None:
+            return self.async_create_entry(data={})
+        return self.async_show_form(
+            step_id="confirm",
+            description_placeholders={
+                "device_name": self._device_name,
+                "channel_index": str(self._channel_index),
+            },
+        )
+
+async def async_create_fix_flow(
+    hass: HomeAssistant, issue_id: str, data: dict | None
+) -> RepairsFlow:
+    """Create the repair flow for a given issue."""
+    if issue_id.startswith("pin_failed_"):
+        return InvalidPinNotificationFlow(
+            hass=hass,
+            entry_id=data["entry_id"],
+            device_name=data["device_name"],
+        )
+    if issue_id.startswith("access_authorization_"):
+        return AccessAuthorizationRepairFlow(
+            device_name=data["device_name"],
+            channel_index=data["channel_index"],
+        )
+    raise ValueError(f"Unknown issue id: {issue_id}")

--- a/custom_components/hcu_integration/repairs.py
+++ b/custom_components/hcu_integration/repairs.py
@@ -4,57 +4,12 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.repairs import RepairsFlow
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 
 from .const import DOMAIN, CONF_PIN
 
 _LOGGER = logging.getLogger(__name__)
-
-
-class InvalidPinNotificationFlow(RepairsFlow):
-    """Repair flow that only informs about an invalid PIN — no input required."""
-
-    def __init__(self, device_name: str) -> None:
-        """Initialize the notification flow."""
-        self._device_name = device_name
-
-    async def async_step_init(self, user_input=None) -> FlowResult:
-        """Handle the first step."""
-        return await self.async_step_confirm()
-
-    async def async_step_confirm(self, user_input=None) -> FlowResult:
-        """Show the PIN failure notice and confirm."""
-        if user_input is not None:
-            return self.async_create_entry(data={})
-
-        return self.async_show_form(
-            step_id="confirm",
-            description_placeholders={"device_name": self._device_name},
-        )
-
-class AccessAuthorizationRepairFlow(RepairsFlow):
-    """Repair flow for CLIENT_ACCESS_DENIED on a device channel."""
-
-    def __init__(self, device_id: str, channel_index: int) -> None:
-        """Initialize the repair flow."""
-        self._device_id = device_id
-        self._channel_index = channel_index
-
-    async def async_step_init(
-        self, user_input: dict | None = None
-    ) -> data_entry_flow.FlowResult:
-        """Handle the first (and only) step."""
-        if user_input is not None:
-            return self.async_create_entry(data={})
-
-        return self.async_show_form(
-            step_id="init",
-            description_placeholders={
-                "device_id": self._device_id,
-                "channel_index": str(self._channel_index),
-            },
-        )
-
 
 class InvalidPinNotificationFlow(RepairsFlow):
     """Repair flow that only informs about an invalid PIN — no input required."""

--- a/custom_components/hcu_integration/text.py
+++ b/custom_components/hcu_integration/text.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.text import TextEntity, TextMode
-from homeassistant.const import Platform
+from homeassistant.const import Platform, EntityCategory
 
 from .const import CONF_PULL_LATCH_PINS
 from .entity import HcuBaseEntity
@@ -38,6 +38,8 @@ class HcuPullLatchPin(HcuBaseEntity, TextEntity):
     _attr_mode = TextMode.PASSWORD
     _attr_native_min = 0
     _attr_native_max = 20
+    _attr_entity_category = EntityCategory.CONFIG
+
 
     def __init__(
         self,

--- a/custom_components/hcu_integration/text.py
+++ b/custom_components/hcu_integration/text.py
@@ -6,7 +6,10 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.text import TextEntity, TextMode
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform, EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import CONF_PULL_LATCH_PINS
 from .entity import HcuBaseEntity

--- a/custom_components/hcu_integration/text.py
+++ b/custom_components/hcu_integration/text.py
@@ -1,0 +1,73 @@
+# custom_components/hcu_integration/text.py
+"""Text entities for the HCU integration."""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from homeassistant.components.text import TextEntity, TextMode
+from homeassistant.const import Platform
+
+from .const import CONF_PULL_LATCH_PINS
+from .entity import HcuBaseEntity
+
+if TYPE_CHECKING:
+    from .api import HcuApiClient
+    from . import HcuCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+async def async_setup_entry(
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        async_add_entities: AddEntitiesCallback,
+    ) -> None:
+        """Set up the text platform from a config entry."""
+        coordinator: "HcuCoordinator" = hass.data[config_entry.domain][
+            config_entry.entry_id
+        ]
+        if entities := coordinator.entities.get(Platform.TEXT):
+            async_add_entities(entities)
+    
+class HcuPullLatchPin(HcuBaseEntity, TextEntity):
+    """PIN input field for a Pull Latch button."""
+
+    PLATFORM = Platform.TEXT
+    _attr_translation_key = "hcu_pull_latch_pin"
+    _attr_icon = "mdi:lock-outline"
+    _attr_mode = TextMode.PASSWORD
+    _attr_native_min = 0
+    _attr_native_max = 20
+
+    def __init__(
+        self,
+        coordinator: "HcuCoordinator",
+        client: "HcuApiClient",
+        device_data: dict,
+        channel_index: str,
+    ) -> None:
+        super().__init__(coordinator, client, device_data, channel_index)
+        self._config_entry = coordinator.config_entry
+        self._set_entity_name(
+            channel_label=self._channel.get("label"), feature_name="Pull Latch PIN"
+        )
+        self._attr_unique_id = f"{self._device_id}_{channel_index}_pull_latch_pin"
+        self._pin_key = f"{self._device_id}_{channel_index}_pull_latch"
+        
+    @property
+    def native_value(self) -> str:
+        return self._config_entry.options.get(CONF_PULL_LATCH_PINS, {}).get(
+            self._pin_key, ""
+        )
+
+    async def async_set_value(self, value: str) -> None:
+        new_pins = dict(self._config_entry.options.get(CONF_PULL_LATCH_PINS, {}))
+        if value:
+            new_pins[self._pin_key] = value
+        else:
+            new_pins.pop(self._pin_key, None)
+        self.hass.config_entries.async_update_entry(
+            self._config_entry,
+            options={**self._config_entry.options, CONF_PULL_LATCH_PINS: new_pins},
+        )
+        self.async_write_ha_state()

--- a/custom_components/hcu_integration/translations/de.json
+++ b/custom_components/hcu_integration/translations/de.json
@@ -359,6 +359,11 @@
                     "tilted": "Gekippt"
                 }
             }
-        }
+        },
+		"text": {
+			"hcu_pull_latch_pin": {
+				"name": "Pull Latch PIN"
+			}
+		}
     }
 }

--- a/custom_components/hcu_integration/translations/de.json
+++ b/custom_components/hcu_integration/translations/de.json
@@ -6,22 +6,16 @@
                 "description": "Geben Sie die Verbindungsdetails für Ihre Homematic IP HCU ein.",
                 "data": {
                     "host": "Hostname oder IP-Adresse",
+					"entity_prefix": "Entitätspräfix (Optional)",
                     "auth_port": "Authentifizierungs-API-Port (Standard: 6969)",
                     "websocket_port": "WebSocket-API-Port (Standard: 9001)"
                 }
             },
             "auth": {
                 "title": "Mit HCU authentifizieren",
-                "description": "Bitte geben Sie den Aktivierungsschlüssel für '{hcu_ip}' aus der HCU WebUI > Einstellungen > Connect ein.",
+                "description": "Bitte geben Sie den Aktivierungsschlüssel für {hcu_ip} aus der HCU WebUI > Einstellungen > Connect ein.",
                 "data": {
                     "activation_key": "Aktivierungsschlüssel"
-                }
-            },
-            "reauth_confirm": {
-                "title": "Türschloss-PIN erforderlich",
-                "description": "{info}",
-                "data": {
-                    "pin": "PIN"
                 }
             },
             "select_oems": {
@@ -30,7 +24,27 @@
                 "data": {
                     "selected_oems": "Zu importierende Hersteller"
                 }
-            }
+            },
+			"reauth_confirm": {
+				"title": "Neu-Autorisierung erforderlich",
+				"description": "Die Integration muss neu autorisiert werden."
+			},
+			"reconfigure": {
+				"title": "HCU neu konfigurieren",
+				"description": "Gib die neuen Verbindungsdetails für deine Homematic IP HCU ein.",
+				"data": {
+					"host": "Hostname oder IP-Adresse",
+					"auth_port": "Authentifizierungs-API-Port",
+					"websocket_port": "WebSocket-API-Port"
+				}
+			},
+			"reconfigure_auth": {
+				"title": "Integration neu autorisieren",
+				"description": "Bitte gib den Aktivierungsschlüssel für {hcu_ip} aus der HCU WebUI > Einstellungen > Connect ein.",
+				"data": {
+					"activation_key": "Aktivierungsschlüssel"
+				}
+			}
         },
         "error": {
             "cannot_connect": "Verbindung zur HCU fehlgeschlagen. Host und Ports prüfen.",
@@ -100,7 +114,32 @@
             "internal_error": "Interner Fehler: Client nicht verfügbar."
         }
     },
-    "device_automation": {
+    "issues": {
+		"pin_failed": {
+			"title": "PIN-Fehler für {device_name}",
+			"description": "Der Autorisierungs-PIN für {device_name} ist fehlgeschlagen.",
+			"fix_flow": {
+				"step": {
+					"confirm": {
+						"title": "PIN anpassen",
+						"description": "Der Autorisierungs-PIN für **{device_name}** ist fehlgeschlagen. Der gerätespezifische PIN hat Vorrang: Öffne die Geräteeinstellungen für {device_name} in Home Assistant und aktualisiere dort den PIN. Alternativ kann der globale PIN unter Einstellungen → Integrationen → Homematic IP HCU → Konfigurieren → Türschloss-PIN aktualisiert werden. Danach die Integration neu laden."
+					}
+				}
+			}
+		},
+		"access_authorization": {
+			"title": "Gerät nicht autorisiert: {device_name} Kanal {channel_index}",
+			"fix_flow": {
+				"step": {
+					"confirm": {
+						"title": "Zugriffsberechtigung einrichten",
+						"description": "Die Integration ist nicht berechtigt, Gerät **{device_name}** Kanal **{channel_index}** zu steuern.\n\nSo behebst du das Problem:\n1. Öffne die **Homematic IP** App\n2. Gehe zu → **Mehr** → **Zugriffsberechtigungen**\n3. Füge den Benutzer **'Home Assistant Integration'** zum Berechtigungsprofil hinzu\n4. Stelle sicher, dass eine PIN hinterlegt ist\n5. Klicke unten auf **Bestätigen** und lade anschließend die Integration in Home Assistant neu."
+					}
+				}
+			}
+		}
+	},
+	"device_automation": {
         "trigger_type": {
             "press_short": "\"Taste {subtype}\": kurz gedrückt",
             "press_long": "\"Taste {subtype}\": lang gedrückt",

--- a/custom_components/hcu_integration/translations/en.json
+++ b/custom_components/hcu_integration/translations/en.json
@@ -6,22 +6,16 @@
                 "description": "Enter the connection details for your Homematic IP HCU.",
                 "data": {
                     "host": "Hostname or IP Address",
+                    "entity_prefix": "Entity Prefix (Optional)",
                     "auth_port": "Authentication API Port (Default: 6969)",
                     "websocket_port": "WebSocket API Port (Default: 9001)"
                 }
             },
             "auth": {
                 "title": "Authenticate with HCU",
-                "description": "Please provide the activation key for '{hcu_ip}' from the HCU WebUI > Settings > Connect.",
+                "description": "Please provide the activation key for {hcu_ip} from the HCU WebUI > Settings > Connect.",
                 "data": {
                     "activation_key": "Activation Key"
-                }
-            },
-            "reauth_confirm": {
-                "title": "Lock PIN Required",
-                "description": "{info}",
-                "data": {
-                    "pin": "PIN"
                 }
             },
             "select_oems": {
@@ -30,7 +24,27 @@
                 "data": {
                     "selected_oems": "Manufacturers to Import"
                 }
-            }
+            },
+			"reauth_confirm": {
+				"title": "Re-authorization Required",
+				"description": "The integration needs to be re-authorized. Please follow the reconfiguration steps."
+			},
+			"reconfigure": {
+				"title": "Reconfigure Homematic IP HCU",
+				"description": "Enter the new connection details for your Homematic IP HCU.",
+				"data": {
+					"host": "Hostname or IP Address",
+					"auth_port": "Authentication API Port",
+					"websocket_port": "WebSocket API Port"
+				}
+			},
+			"reconfigure_auth": {
+				"title": "Re-authorize Integration",
+				"description": "Please provide the activation key for {hcu_ip} from the HCU WebUI > Settings > Connect.",
+				"data": {
+					"activation_key": "Activation Key"
+				}
+			}
         },
         "error": {
             "cannot_connect": "Failed to connect to the HCU. Check host and ports.",
@@ -100,7 +114,32 @@
             "internal_error": "Internal error: Client not available."
         }
     },
-    "device_automation": {
+    "issues": {
+		"pin_failed": {
+			"title": "PIN failed for {device_name}",
+			"description": "The authorization PIN for {device_name} failed.",
+			"fix_flow": {
+				"step": {
+					"confirm": {
+						"title": "Update PIN",
+						"description": "The authorization PIN for **{device_name}** failed. The device-specific PIN takes priority: open the device settings for {device_name} in Home Assistant and update the PIN there. Alternatively, you can update the global PIN under Settings → Integrations → Homematic IP HCU → Configure → Lock PIN. After updating, reload the integration."
+					}
+				}
+			}
+		},
+		"access_authorization": {
+			"title": "Device not authorized: {device_name} channel {channel_index}",
+			"fix_flow": {
+				"step": {
+					"confirm": {
+						"title": "Fix access authorization",
+						"description": "The integration is not authorized to control device **{device_name}** channel **{channel_index}**.\n\nTo fix this:\n1. Open the **Homematic IP** app\n2. Go to → **More** → **Access authorisations**\n3. Add **'Home Assistant Integration'** to the authorisation profile\n4. Ensure a PIN is set\n5. Click **Submit** below, then reload the integration."
+					}
+				}
+			}
+		}
+	},
+	"device_automation": {
         "trigger_type": {
             "press_short": "\"Button {subtype}\" was pressed short",
             "press_long": "\"Button {subtype}\" was pressed long",

--- a/custom_components/hcu_integration/translations/en.json
+++ b/custom_components/hcu_integration/translations/en.json
@@ -359,6 +359,11 @@
                     "tilted": "Tilted"
                 }
             }
-        }
+        },
+		"text": {
+			"hcu_pull_latch_pin": {
+				"name": "Pull Latch PIN"
+			}
+		}
     }
 }


### PR DESCRIPTION
## Summary

This PR adds full support for the **HmIP-FDC** (Door Communication Module) including its access-authorization model, per-device PIN management, and improved error reporting via HA Repairs.

---

## What's new

### HmIP-FDC: Access Authorization Channel

The FDC uses a dedicated `ACCESS_AUTHORIZATION_CHANNEL` instead of the `DOOR_SWITCH_CHANNEL` to trigger the pull latch. The integration now:

- Finds the correct `ACCESS_AUTHORIZATION_CHANNEL` that belongs to the same switch group as the door button.
- Verifies that the integration's `clientId` is listed in an `ACCESS_AUTHORIZATION_PROFILE` that has a PIN assigned.
- Uses that channel index when calling `async_pull_latch`, so the HCU applies the correct authorization rules.

### Per-device PIN via Text entity (`HcuPullLatchPin`)

A new **password-mode config entity** (`Platform.TEXT`) is created for every `DOOR_SWITCH_CHANNEL`. It lets users store a device-specific PIN directly in Home Assistant without going through the options flow. The PIN hierarchy is:

1. Device-specific PIN (stored in `CONF_PULL_LATCH_PINS` options)
2. Global PIN from the config entry (`CONF_PIN`)

### Client ID persistence (`CONF_CLIENT_ID`)

The `clientId` returned by the HCU during token confirmation is now saved to the config entry. It is used during authorization checks and is refreshed whenever the user runs the reconfigure flow.

### Reconfigure flow rewrite

`async_step_reconfigure` is now a two-step flow:

1. **Step 1 – Connection** (`reconfigure`): user updates host and ports.
2. **Step 2 – Token renewal** (`reconfigure_auth`): user enters an activation key to get a fresh token and `clientId`.

The old single-step reconfigure (which reused the existing token) and the separate `reauth_confirm` step (PIN-only reauth) are replaced by this unified flow.

### HA Repairs integration

Instead of triggering a full re-authentication on PIN failure, the integration now raises actionable issues in **Settings → Repairs**:

| Issue ID | Trigger | Repair action |
|---|---|---|
| `pin_failed_<device_id>` | PIN rejected by the HCU | Reload the integration after fixing the PIN |
| `access_authorization_<device_id>_<ch>` | Integration not in any `ACCESS_AUTHORIZATION_PROFILE` | Follow in-app instructions to add the HA user |

Both flows guide the user with clear instructions and are dismissed automatically when the situation is resolved.

---

## Files changed

| File | Change |
|---|---|
| `button.py` | `HcuDoorPullLatchButton` – authorization channel lookup, PIN hierarchy, Repairs issues; `HcuDoorUnlatchButton` – PIN read from associated lock |
| `text.py` | New `HcuPullLatchPin` entity (password text, config category) |
| `repairs.py` | New `InvalidPinNotificationFlow` and `AccessAuthorizationRepairFlow` + `async_create_fix_flow` |
| `config_flow.py` | Two-step reconfigure flow, `clientId` capture, `_config_data` moved to instance variable, `async_setup` moved to `__init__.py` |
| `__init__.py` | `async_setup` added here (was incorrectly in `config_flow.py`) |
| `const.py` | `CONF_PULL_LATCH_PINS`, `CONF_CLIENT_ID`, `Platform.TEXT` platform, `extra_entities` for `DOOR_SWITCH_CHANNEL` |
| `translations/de.json` / `en.json` | Translations for new text entity, repair flows, and reconfigure steps |

---

## Setup instructions for FDC users

1. After updating, go to **Settings → Integrations → Homematic IP HCU → Configure** to run the reconfigure flow and obtain a fresh `clientId`.
2. In the **Homematic IP app**, go to **More → Access authorisations**, open your profile, add the **Home Assistant Integration** user, and make sure a PIN is set.
3. Optionally, set a per-device PIN directly on the new `Pull Latch PIN` entity in Home Assistant (overrides the global PIN).
4. Press the `Pull Latch` button — if anything is misconfigured, a Repair issue will guide you to the fix.

---

## Test plan

- [ ] FDC pull latch triggers correctly when `clientId` is in an authorized profile with PIN
- [ ] `access_authorization_*` Repair issue appears when integration is not in any profile
- [ ] `pin_failed_*` Repair issue appears on wrong PIN; dismissed after fixing
- [ ] Per-device PIN on `HcuPullLatchPin` text entity overrides global PIN
- [ ] Reconfigure flow (two steps) saves new token + `clientId`
- [ ] Existing lock/unlatch behavior (DOOR_LOCK_CHANNEL) is unaffected


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3NboVhsuwyt5SRMQfYJKw)_