### PR TITLE
Main v2.0.0 Use Internal On Time — Config Switch Entity per Channel

### DIFF
--- a/custom_components/hcu_integration/api.py
+++ b/custom_components/hcu_integration/api.py
@@ -737,7 +737,7 @@ class HcuApiClient:
             body["rampTime"] = ramp_time
         if on_time is not None:
             body["onTime"] = on_time
-        api_path = self._get_api_path_with_optional_time("SET_DIM_LEVEL", "SET_DIM_LEVEL_WITH_TIME", ramp_time or on_time)
+        api_path = self._get_api_path_with_optional_time("SET_DIM_LEVEL", "SET_DIM_LEVEL_WITH_TIME", ramp_time if ramp_time is not None else on_time)
         await self.async_device_control(api_path, device_id, channel_index, body)
 
     async def async_set_color_temperature(self, device_id: str, channel_index: int, color_temp: int, dim_level: float, ramp_time: float | None = None) -> None:

--- a/custom_components/hcu_integration/api.py
+++ b/custom_components/hcu_integration/api.py
@@ -731,11 +731,13 @@ class HcuApiClient:
         path = self._get_api_path_with_optional_time("SET_WATERING_SWITCH_STATE", "SET_WATERING_SWITCH_STATE_WITH_TIME", effective_on_time)
         await self.async_device_control(path, device_id, channel_index, body)
 
-    async def async_set_dim_level(self, device_id: str, channel_index: int, dim_level: float, ramp_time: float | None = None) -> None:
+    async def async_set_dim_level(self, device_id: str, channel_index: int, dim_level: float, ramp_time: float | None = None, on_time: float | None = None) -> None:
         body = {"dimLevel": dim_level}
         if ramp_time is not None:
             body["rampTime"] = ramp_time
-        api_path = self._get_api_path_with_optional_time("SET_DIM_LEVEL", "SET_DIM_LEVEL_WITH_TIME", ramp_time)
+        if on_time is not None:
+            body["onTime"] = on_time
+        api_path = self._get_api_path_with_optional_time("SET_DIM_LEVEL", "SET_DIM_LEVEL_WITH_TIME", ramp_time or on_time)
         await self.async_device_control(api_path, device_id, channel_index, body)
 
     async def async_set_color_temperature(self, device_id: str, channel_index: int, color_temp: int, dim_level: float, ramp_time: float | None = None) -> None:

--- a/custom_components/hcu_integration/const.py
+++ b/custom_components/hcu_integration/const.py
@@ -997,7 +997,8 @@ HMIP_FEATURE_TO_ENTITY = {
         "state_class": SensorStateClass.TOTAL_INCREASING,
         "entity_category": EntityCategory.DIAGNOSTIC,
         "entity_registry_enabled_default": False,
-        "suggested_display_precision": 0, 
+        "suggested_display_precision": 0,
+        "config_companion": "HcuConfigUseInternalOnTime",
     },
     
 }
@@ -1073,23 +1074,23 @@ HMIP_CHANNEL_ROLE_TO_ENTITY = {
 }
     
 HMIP_CHANNEL_TYPE_TO_ENTITY = {
-    "DIMMER_CHANNEL": {"class": "HcuLight", "extra_entities": ["HcuConfigUseInternalOnTime"]},
-    "MULTI_MODE_INPUT_DIMMER_CHANNEL": {"class": "HcuLight", "extra_entities": ["HcuConfigUseInternalOnTime"]},
-    "RGBW_AUTOMATION_CHANNEL": {"class": "HcuLight", "extra_entities": ["HcuConfigUseInternalOnTime"]},
-    "UNIVERSAL_LIGHT_CHANNEL": {"class": "HcuLight", "extra_entities": ["HcuConfigUseInternalOnTime"]},
-    "NOTIFICATION_LIGHT_CHANNEL": {"class": "HcuLight", "extra_entities": ["HcuConfigUseInternalOnTime"]},
-    "OPTICAL_SIGNAL_CHANNEL": {"class": "HcuLight", "extra_entities": ["HcuConfigUseInternalOnTime"]},
-    "NOTIFICATION_MP3_SOUND_CHANNEL": {"class": "HcuNotificationLight", "extra_entities": ["HcuConfigUseInternalOnTime"]},
-    "BACKLIGHT_CHANNEL": {"class": "HcuLight", "extra_entities": ["HcuConfigUseInternalOnTime"]},
+    "DIMMER_CHANNEL": {"class": "HcuLight"},
+    "MULTI_MODE_INPUT_DIMMER_CHANNEL": {"class": "HcuLight"},
+    "RGBW_AUTOMATION_CHANNEL": {"class": "HcuLight"},
+    "UNIVERSAL_LIGHT_CHANNEL": {"class": "HcuLight"},
+    "NOTIFICATION_LIGHT_CHANNEL": {"class": "HcuLight"},
+    "OPTICAL_SIGNAL_CHANNEL": {"class": "HcuLight"},
+    "NOTIFICATION_MP3_SOUND_CHANNEL": {"class": "HcuNotificationLight"},
+    "BACKLIGHT_CHANNEL": {"class": "HcuLight"},
     "ALARM_SIREN_CHANNEL": {"class": "HcuSiren"},
-    "SWITCH_CHANNEL": {"class": "HcuSwitch", "extra_entities": ["HcuConfigUseInternalOnTime"]},
-    "SWITCH_MEASURING_CHANNEL": {"class": "HcuSwitch", "extra_entities": ["HcuConfigUseInternalOnTime"]},
-    "WIRED_SWITCH_CHANNEL": {"class": "HcuSwitch", "extra_entities": ["HcuConfigUseInternalOnTime"]},
-    "MULTI_MODE_INPUT_SWITCH_CHANNEL": {"class": "HcuSwitch", "extra_entities": ["HcuConfigUseInternalOnTime"]},
-    "WATERING_ACTUATOR_CHANNEL": {"class": "HcuWateringSwitch", "extra_entities": ["HcuConfigUseInternalOnTime"]},
-    "WATERING_CONTROLLER_CHANNEL": {"class": "HcuWateringSwitch", "extra_entities": ["HcuConfigUseInternalOnTime"]},
-    "CONDITIONAL_SWITCH_CHANNEL": {"class": "HcuSwitch", "extra_entities": ["HcuConfigUseInternalOnTime"]},
-    "OPEN_COLLECTOR_CHANNEL_8": {"class": "HcuSwitch", "extra_entities": ["HcuConfigUseInternalOnTime"]},
+    "SWITCH_CHANNEL": {"class": "HcuSwitch"},
+    "SWITCH_MEASURING_CHANNEL": {"class": "HcuSwitch"},
+    "WIRED_SWITCH_CHANNEL": {"class": "HcuSwitch"},
+    "MULTI_MODE_INPUT_SWITCH_CHANNEL": {"class": "HcuSwitch"},
+    "WATERING_ACTUATOR_CHANNEL": {"class": "HcuWateringSwitch"},
+    "WATERING_CONTROLLER_CHANNEL": {"class": "HcuWateringSwitch"},
+    "CONDITIONAL_SWITCH_CHANNEL": {"class": "HcuSwitch"},
+    "OPEN_COLLECTOR_CHANNEL_8": {"class": "HcuSwitch"},
     "SHUTTER_CHANNEL": {"class": "HcuCover"},
     "BLIND_CHANNEL": {"class": "HcuCover"},
     "BRAND_BLIND_CHANNEL": {"class": "HcuCover"},  # For HmIP-HDM1 HunterDouglas blinds
@@ -1118,7 +1119,7 @@ HMIP_CHANNEL_TYPE_TO_ENTITY = {
     "TEMPERATURE_SENSOR_2_EXTERNAL_DELTA_CHANNEL": None,
     "WALL_MOUNTED_THERMOSTAT_CARBON_CHANNEL": None,
     "WALL_MOUNTED_THERMOSTAT_CHANNEL": None,
-    "EXTERNAL_SWITCH_CHANNEL": {"class": "HcuSwitch", "extra_entities": ["HcuConfigUseInternalOnTime"]},
+    "EXTERNAL_SWITCH_CHANNEL": {"class": "HcuSwitch"},
 }
 
 # --- Simple RGB Color State Constants ---

--- a/custom_components/hcu_integration/const.py
+++ b/custom_components/hcu_integration/const.py
@@ -1073,23 +1073,23 @@ HMIP_CHANNEL_ROLE_TO_ENTITY = {
 }
     
 HMIP_CHANNEL_TYPE_TO_ENTITY = {
-    "DIMMER_CHANNEL": {"class": "HcuLight"},
-    "MULTI_MODE_INPUT_DIMMER_CHANNEL": {"class": "HcuLight"}, 
-    "RGBW_AUTOMATION_CHANNEL": {"class": "HcuLight"},
-    "UNIVERSAL_LIGHT_CHANNEL": {"class": "HcuLight"},
-    "NOTIFICATION_LIGHT_CHANNEL": {"class": "HcuLight"},
-    "OPTICAL_SIGNAL_CHANNEL": {"class": "HcuLight"},
-    "NOTIFICATION_MP3_SOUND_CHANNEL": {"class": "HcuNotificationLight"},
-    "BACKLIGHT_CHANNEL": {"class": "HcuLight"},
+    "DIMMER_CHANNEL": {"class": "HcuLight", "extra_entities": ["HcuConfigUseInternalOnTime"]},
+    "MULTI_MODE_INPUT_DIMMER_CHANNEL": {"class": "HcuLight", "extra_entities": ["HcuConfigUseInternalOnTime"]},
+    "RGBW_AUTOMATION_CHANNEL": {"class": "HcuLight", "extra_entities": ["HcuConfigUseInternalOnTime"]},
+    "UNIVERSAL_LIGHT_CHANNEL": {"class": "HcuLight", "extra_entities": ["HcuConfigUseInternalOnTime"]},
+    "NOTIFICATION_LIGHT_CHANNEL": {"class": "HcuLight", "extra_entities": ["HcuConfigUseInternalOnTime"]},
+    "OPTICAL_SIGNAL_CHANNEL": {"class": "HcuLight", "extra_entities": ["HcuConfigUseInternalOnTime"]},
+    "NOTIFICATION_MP3_SOUND_CHANNEL": {"class": "HcuNotificationLight", "extra_entities": ["HcuConfigUseInternalOnTime"]},
+    "BACKLIGHT_CHANNEL": {"class": "HcuLight", "extra_entities": ["HcuConfigUseInternalOnTime"]},
     "ALARM_SIREN_CHANNEL": {"class": "HcuSiren"},
-    "SWITCH_CHANNEL": {"class": "HcuSwitch"},
-    "SWITCH_MEASURING_CHANNEL": {"class": "HcuSwitch"},
-    "WIRED_SWITCH_CHANNEL": {"class": "HcuSwitch"},
-    "MULTI_MODE_INPUT_SWITCH_CHANNEL": {"class": "HcuSwitch"},
-    "WATERING_ACTUATOR_CHANNEL": {"class": "HcuWateringSwitch"},
-    "WATERING_CONTROLLER_CHANNEL": {"class": "HcuWateringSwitch"},
-    "CONDITIONAL_SWITCH_CHANNEL": {"class": "HcuSwitch"},
-    "OPEN_COLLECTOR_CHANNEL_8": {"class": "HcuSwitch"},
+    "SWITCH_CHANNEL": {"class": "HcuSwitch", "extra_entities": ["HcuConfigUseInternalOnTime"]},
+    "SWITCH_MEASURING_CHANNEL": {"class": "HcuSwitch", "extra_entities": ["HcuConfigUseInternalOnTime"]},
+    "WIRED_SWITCH_CHANNEL": {"class": "HcuSwitch", "extra_entities": ["HcuConfigUseInternalOnTime"]},
+    "MULTI_MODE_INPUT_SWITCH_CHANNEL": {"class": "HcuSwitch", "extra_entities": ["HcuConfigUseInternalOnTime"]},
+    "WATERING_ACTUATOR_CHANNEL": {"class": "HcuWateringSwitch", "extra_entities": ["HcuConfigUseInternalOnTime"]},
+    "WATERING_CONTROLLER_CHANNEL": {"class": "HcuWateringSwitch", "extra_entities": ["HcuConfigUseInternalOnTime"]},
+    "CONDITIONAL_SWITCH_CHANNEL": {"class": "HcuSwitch", "extra_entities": ["HcuConfigUseInternalOnTime"]},
+    "OPEN_COLLECTOR_CHANNEL_8": {"class": "HcuSwitch", "extra_entities": ["HcuConfigUseInternalOnTime"]},
     "SHUTTER_CHANNEL": {"class": "HcuCover"},
     "BLIND_CHANNEL": {"class": "HcuCover"},
     "BRAND_BLIND_CHANNEL": {"class": "HcuCover"},  # For HmIP-HDM1 HunterDouglas blinds
@@ -1118,7 +1118,7 @@ HMIP_CHANNEL_TYPE_TO_ENTITY = {
     "TEMPERATURE_SENSOR_2_EXTERNAL_DELTA_CHANNEL": None,
     "WALL_MOUNTED_THERMOSTAT_CARBON_CHANNEL": None,
     "WALL_MOUNTED_THERMOSTAT_CHANNEL": None,
-    "EXTERNAL_SWITCH_CHANNEL": {"class": "HcuSwitch"},
+    "EXTERNAL_SWITCH_CHANNEL": {"class": "HcuSwitch", "extra_entities": ["HcuConfigUseInternalOnTime"]},
 }
 
 # --- Simple RGB Color State Constants ---

--- a/custom_components/hcu_integration/discovery.py
+++ b/custom_components/hcu_integration/discovery.py
@@ -353,7 +353,7 @@ async def async_discover_entities(
                             uid = getattr(entity, "unique_id", None)
                             if uid:
                                 valid_entity_unique_ids.add(uid)
-                                
+
                         # Add reset button for water volume
                         if feature == "waterVolume":
                             entity = button.HcuResetWaterVolume(coordinator, client, device_data, channel_index)
@@ -361,6 +361,23 @@ async def async_discover_entities(
                             uid = getattr(entity, "unique_id", None)
                             if uid:
                                 valid_entity_unique_ids.add(uid)
+
+                        # Create companion config entity if defined (e.g. HcuConfigUseInternalOnTime for onTime).
+                        # unique_id includes channel_index, so multiple channels per device are handled correctly.
+                        if companion_class_name := mapping.get("config_companion"):
+                            if companion_module := class_module_map.get(companion_class_name):
+                                try:
+                                    companion_class = getattr(companion_module, companion_class_name)
+                                    companion = companion_class(coordinator, client, device_data, channel_index)
+                                    entities[companion.PLATFORM].append(companion)
+                                    c_uid = getattr(companion, "unique_id", None)
+                                    if c_uid:
+                                        valid_entity_unique_ids.add(c_uid)
+                                except (AttributeError, TypeError) as e:
+                                    _LOGGER.error(
+                                        "Failed to create config companion '%s' for device %s, channel %s: %s",
+                                        companion_class_name, device_data.get("id"), channel_index, e,
+                                    )
                                 
 
                     except (AttributeError, TypeError) as e:

--- a/custom_components/hcu_integration/discovery.py
+++ b/custom_components/hcu_integration/discovery.py
@@ -84,6 +84,7 @@ async def async_discover_entities(
         "HcuSiren": siren,
         "HcuSwitch": switch,
         "HcuWateringSwitch": switch,
+        "HcuConfigUseInternalOnTime": switch,
         "HcuCover": cover,
         "HcuGarageDoorCover": cover,
         "HcuDoorbellEvent": event,

--- a/custom_components/hcu_integration/entity.py
+++ b/custom_components/hcu_integration/entity.py
@@ -332,13 +332,18 @@ class HcuBaseEntity(CoordinatorEntity["HcuCoordinator"], HcuEntityPrefixMixin, E
                 attrs["attr_name"] = self._attr_name
             if hasattr(self, "_attr_has_entity_name"):
                 attrs["attr_has_entity_name"] = self._attr_has_entity_name
+            if hasattr(self, "_attr_translation_key"):
+                attrs["attr_translation_key"] = self._attr_translation_key
             if hasattr(self, "object_id_base"):
                 attrs["object_id_base"] = self.object_id_base
             if hasattr(self, "suggested_object_id"):
                 attrs["suggested_object_id"] = self.suggested_object_id
             switchVisualization = self._channel.get("switchVisualization")
             if switchVisualization is not None:
-                attrs["switchVisualization"] = switchVisualization
+                attrs["switch_visualization"] = switchVisualization
+            channelRole = self._channel.get("channelRole")
+            if channelRole is not None:
+                attrs["channel_role"] = channelRole
         
         return attrs
     

--- a/custom_components/hcu_integration/entity.py
+++ b/custom_components/hcu_integration/entity.py
@@ -3,13 +3,15 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 import logging
 
+from homeassistant.const import STATE_ON
 from homeassistant.core import callback
 from homeassistant.helpers.entity import DeviceInfo, Entity
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, CONF_ENTITY_PREFIX, HOMEMATIC_MODEL_PREFIXES, CONF_ADVANCED_ATTRIBUTES, CONF_PIN, CONF_DEVICE_PINS, CONF_CLIENT_ID
+from .const import DOMAIN, CONF_ENTITY_PREFIX, HOMEMATIC_MODEL_PREFIXES, CONF_ADVANCED_ATTRIBUTES, CONF_PIN, CONF_DEVICE_PINS, CONF_CLIENT_ID, HMIP_ON_TIME_INFINITE
 from .api import HcuApiClient, HcuApiError
 from .util import get_device_manufacturer
 
@@ -371,6 +373,22 @@ class HcuBaseEntity(CoordinatorEntity["HcuCoordinator"], HcuEntityPrefixMixin, E
         maintenance_channel = self._device.get("functionalChannels", {}).get("0", {})
         return not maintenance_channel.get("unreach", False)
 
+
+    def _get_internal_on_time(self) -> float | None:
+        """Return onTime if the companion 'Use Internal On Time' config switch is ON, else None."""
+        companion_uid = f"{self._device_id}_{self._channel_index}_use_internal_on_time"
+        registry = er.async_get(self.hass)
+        entity_id = registry.async_get_entity_id("switch", DOMAIN, companion_uid)
+        if entity_id is None:
+            return None
+        state = self.hass.states.get(entity_id)
+        if state is None or state.state != STATE_ON:
+            return None
+        internal_link = self._channel.get("internalLinkConfiguration") or {}
+        on_time = self._channel.get("onTime") or internal_link.get("onTime") or 0
+        if on_time == 0 or on_time == HMIP_ON_TIME_INFINITE:
+            return None
+        return float(on_time)
 
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""

--- a/custom_components/hcu_integration/light.py
+++ b/custom_components/hcu_integration/light.py
@@ -23,7 +23,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .switch import HcuSwitch
 from .entity import HcuBaseEntity, HcuSwitchingGroupBase
-from .api import HcuApiClient
+from .api import HcuApiClient, HcuApiError
 from .const import (
     API_PATHS,
     HMIP_RGB_COLOR_MAP,
@@ -223,8 +223,27 @@ class HcuLight(HcuBaseEntity, LightEntity):
         """
         return _convert_hs_to_simple_rgb(hs_color)
 
+    async def async_turn_on_with_time(self, on_time: float) -> None:
+        """Turn the light on for a specific duration using the configured internal on-time."""
+        self._attr_assumed_state = True
+        self.async_write_ha_state()
+        try:
+            current_brightness = self.brightness if self.is_on else None
+            dim_level = (current_brightness or 255) / 255.0
+            await self._client.async_set_dim_level(
+                self._device_id, self._channel_index, dim_level, on_time=on_time
+            )
+        except (HcuApiError, ConnectionError) as err:
+            _LOGGER.error("Failed to turn on %s with time: %s", self.name, err)
+            self._attr_assumed_state = False
+            self.async_write_ha_state()
+
     async def async_turn_on(self, **kwargs) -> None:
         """Turn the light on with optional color, temperature, brightness, or effect adjustments."""
+        if not kwargs and (on_time := self._get_internal_on_time()):
+            await self.async_turn_on_with_time(on_time)
+            return
+
         # Default to current brightness if the light is on, otherwise 100%.
         current_brightness = self.brightness if self.is_on else None
         target_brightness = kwargs.get(ATTR_BRIGHTNESS, current_brightness or 255)

--- a/custom_components/hcu_integration/switch.py
+++ b/custom_components/hcu_integration/switch.py
@@ -198,7 +198,7 @@ class HcuConfigUseInternalOnTime(RestoreEntity, HcuBaseEntity, SwitchEntity):
     ):
         super().__init__(coordinator, client, device_data, channel_index)
         self._set_entity_name(channel_label=self._channel.get("label"), feature_name="Use Internal On Time")
-        self._attr_unique_id = f"{self._device_id}_{self._channel_index}_useInternalOnTime"
+        self._attr_unique_id = f"{self._device_id}_{self._channel_index}_use_internal_on_time"
         self._attr_is_on = False
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/hcu_integration/switch.py
+++ b/custom_components/hcu_integration/switch.py
@@ -197,7 +197,7 @@ class HcuConfigUseInternalOnTime(RestoreEntity, HcuBaseEntity, SwitchEntity):
         channel_index: str,
     ):
         super().__init__(coordinator, client, device_data, channel_index)
-        self._set_entity_name(feature_name="Use Internal On Time")
+        self._set_entity_name(channel_label=self._channel.get("label"), feature_name="Use Internal On Time")
         self._attr_unique_id = f"{self._device_id}_{self._channel_index}_useInternalOnTime"
         self._attr_is_on = False
 

--- a/custom_components/hcu_integration/switch.py
+++ b/custom_components/hcu_integration/switch.py
@@ -211,7 +211,8 @@ class HcuConfigUseInternalOnTime(RestoreEntity, HcuBaseEntity, SwitchEntity):
         return self._attr_is_on
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        on_time = self._channel.get("onTime", 0) or 0
+        internal_link = self._channel.get("internalLinkConfiguration") or {}
+        on_time = self._channel.get("onTime") or internal_link.get("onTime") or 0
         if on_time == 0 or on_time == HMIP_ON_TIME_INFINITE:
             _LOGGER.debug(
                 "Cannot enable 'Use Internal On Time' for %s: onTime is not configured (value: %s)",

--- a/custom_components/hcu_integration/switch.py
+++ b/custom_components/hcu_integration/switch.py
@@ -190,6 +190,7 @@ class HcuConfigUseInternalOnTime(RestoreEntity, HcuBaseEntity, SwitchEntity):
 
     PLATFORM = Platform.SWITCH
     _attr_entity_category = EntityCategory.CONFIG
+    _attr_entity_registry_enabled_default = False
     _attr_icon = "mdi:timer-cog-outline"
 
     def __init__(

--- a/custom_components/hcu_integration/switch.py
+++ b/custom_components/hcu_integration/switch.py
@@ -3,9 +3,10 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.switch import SwitchEntity, SwitchDeviceClass
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
+from homeassistant.const import Platform, STATE_ON, EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 
 import logging
 from .const import HMIP_DEVICE_TYPE_TO_DEVICE_CLASS, API_PATHS
@@ -176,6 +177,49 @@ class HcuWateringSwitch(SwitchStateMixin, HcuBaseEntity, SwitchEntity):
             self._attr_is_on = previous_is_on
             self._attr_assumed_state = previous_assumed_state
             self.async_write_ha_state()
+
+
+class HcuConfigUseInternalOnTime(RestoreEntity, HcuBaseEntity, SwitchEntity):
+    """HA-local config switch per channel: whether to use internal on-time when switching.
+
+    State is stored in HA only (not in HCU). Default: off.
+    """
+
+    PLATFORM = Platform.SWITCH
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_icon = "mdi:timer-cog-outline"
+
+    def __init__(
+        self,
+        coordinator: "HcuCoordinator",
+        client: HcuApiClient,
+        device_data: dict,
+        channel_index: str,
+    ):
+        super().__init__(coordinator, client, device_data, channel_index)
+        self._set_entity_name(feature_name="Use Internal On Time")
+        self._attr_unique_id = f"{self._device_id}_{self._channel_index}_useInternalOnTime"
+        self._attr_is_on = False
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        if (last_state := await self.async_get_last_state()) is not None:
+            self._attr_is_on = last_state.state == STATE_ON
+
+    @property
+    def is_on(self) -> bool:
+        return self._attr_is_on
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        self._attr_is_on = True
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        self._attr_is_on = False
+        self.async_write_ha_state()
+
+    def _handle_coordinator_update(self) -> None:
+        pass
 
 
 class HcuSwitchGroup(HcuSwitchingGroupBase, SwitchEntity):

--- a/custom_components/hcu_integration/switch.py
+++ b/custom_components/hcu_integration/switch.py
@@ -74,6 +74,9 @@ class HcuSwitch(SwitchStateMixin, HcuBaseEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
+        if on_time := self._get_internal_on_time():
+            await self.async_turn_on_with_time(on_time)
+            return
         await self._async_set_optimistic_state(True, "switch")
 
     async def async_turn_off(self, **kwargs: Any) -> None:

--- a/custom_components/hcu_integration/switch.py
+++ b/custom_components/hcu_integration/switch.py
@@ -206,6 +206,17 @@ class HcuConfigUseInternalOnTime(RestoreEntity, HcuBaseEntity, SwitchEntity):
         if (last_state := await self.async_get_last_state()) is not None:
             self._attr_is_on = last_state.state == STATE_ON
 
+        if self._attr_is_on:
+            internal_link = self._channel.get("internalLinkConfiguration") or {}
+            on_time = self._channel.get("onTime") or internal_link.get("onTime") or 0
+            if on_time == 0 or on_time == HMIP_ON_TIME_INFINITE:
+                _LOGGER.debug(
+                    "Disabling 'Use Internal On Time' for %s on startup: onTime is not configured (value: %s)",
+                    self.name,
+                    on_time,
+                )
+                self._attr_is_on = False
+
     @property
     def is_on(self) -> bool:
         return self._attr_is_on

--- a/custom_components/hcu_integration/switch.py
+++ b/custom_components/hcu_integration/switch.py
@@ -9,7 +9,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
 import logging
-from .const import HMIP_DEVICE_TYPE_TO_DEVICE_CLASS, API_PATHS
+from .const import HMIP_DEVICE_TYPE_TO_DEVICE_CLASS, HMIP_ON_TIME_INFINITE, API_PATHS
 from .entity import HcuBaseEntity, SwitchStateMixin, HcuSwitchingGroupBase
 from .api import HcuApiClient, HcuApiError
 
@@ -211,6 +211,14 @@ class HcuConfigUseInternalOnTime(RestoreEntity, HcuBaseEntity, SwitchEntity):
         return self._attr_is_on
 
     async def async_turn_on(self, **kwargs: Any) -> None:
+        on_time = self._channel.get("onTime", 0) or 0
+        if on_time == 0 or on_time == HMIP_ON_TIME_INFINITE:
+            _LOGGER.debug(
+                "Cannot enable 'Use Internal On Time' for %s: onTime is not configured (value: %s)",
+                self.name,
+                on_time,
+            )
+            return
         self._attr_is_on = True
         self.async_write_ha_state()
 


### PR DESCRIPTION
## Use Internal On Time — Config Switch Entity per Channel
### What was done
For all switch and light channels that have an `onTime` sensor entity (i.e., channels with an `internalLinkConfiguration` containing a configured `onTime` value), an additional config entity is automatically created:
**"Use Internal On Time"** (`EntityCategory.CONFIG`, disabled by default)
The switch controls whether turning on a channel passes the internally configured `onTime` to the HCU API — causing the device to automatically turn itself off after the configured duration.
### Behavior
- **Default:** `false` (hidden, must be manually enabled in HA)
- **State is persisted** via `RestoreEntity` — survives HA restarts
- **Validation on enable:** If `onTime == 0` or `onTime == HMIP_ON_TIME_INFINITE (111600)`, the switch cannot be turned on and a debug message is logged
- **Validation on HA startup:** If the switch was last saved as `on` but `onTime` is no longer configured, it is automatically reset to `off`
- **No HCU API call** for the switch itself — purely HA-local configuration
### How the switch is used
When `Use Internal On Time` is enabled for a channel:
- **HcuSwitch:** `async_turn_on` calls `async_turn_on_with_time(onTime)` instead of the normal turn-on flow
- **HcuLight:** `async_turn_on` (with no additional kwargs like brightness/color) calls `async_turn_on_with_time(onTime)`; service calls with explicit parameters follow the normal path
## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

## How Was It Tested?
- [ ] Unit tests
- [x] Manually tested

## Checklist
- [x] Code follows the project style
- [ ] Tests added
- [ ] Documentation updated