### PR TITLE
Add set_cooling_mode service for system-wide cooling control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Homematic IP Local (HCU) integration will be documented in this file.
 
-## 2.0.0.beta6 - 2026-05-17
+## 2.0.0.beta7 - 2026-05-x
 
 > [!NOTE]
 > Please take your time with this update. Due to the breaking changes listed below, carefully review all your automations before updating.
@@ -28,6 +28,7 @@ All notable changes to the Homematic IP Local (HCU) integration will be document
 - Added device trigger support, making it easier to use button presses directly as triggers in automations. More in README.md
 - Device Channels that have not been configured in the Homematic IP app are no longer displayed. (#255)
 - Added **"Use Internal On Time"** config switch entity per channel. When enabled, turning on a switch or light channel passes the `onTime` configured in the Homematic IP app for the internal button, causing the device to turn itself off automatically after the set duration. This makes it possible to use the configured on-time via HomeKit as well — useful for example for staircase lighting (e.g. HmIP-DRSI1) or water valves on devices like the (e.g. HmIP-MOD-OC8). The entity is disabled by default and only appears on channels where an `onTime` value is configured. State is persisted across HA restarts.
+- Added **set_cooling_mode** action to simplify enabling and disabling cooling mode in the HCU
 
 ### HmIP-FDC & Lock
 

--- a/README.md
+++ b/README.md
@@ -691,20 +691,12 @@ action: hcu_integration.deactivate_absence_mode
 
 ### `hcu_integration.set_cooling_mode`
 
-Activates or deactivates the system-wide cooling mode for all heating groups.
+Activates or deactivates cooling mode for all heating groups.
 
-**Example – activate cooling:**
 ```yaml
 action: hcu_integration.set_cooling_mode
 data:
   cooling: true
-```
-
-**Example – deactivate cooling:**
-```yaml
-action: hcu_integration.set_cooling_mode
-data:
-  cooling: false
 ```
 
 ### `hcu_integration.send_api_command`

--- a/README.md
+++ b/README.md
@@ -689,6 +689,24 @@ Deactivate any active absence mode.
 action: hcu_integration.deactivate_absence_mode
 ```
 
+### `hcu_integration.set_cooling_mode`
+
+Activates or deactivates the system-wide cooling mode for all heating groups.
+
+**Example – activate cooling:**
+```yaml
+action: hcu_integration.set_cooling_mode
+data:
+  cooling: true
+```
+
+**Example – deactivate cooling:**
+```yaml
+action: hcu_integration.set_cooling_mode
+data:
+  cooling: false
+```
+
 ### `hcu_integration.send_api_command`
 
 Send raw api command to hcu.

--- a/custom_components/hcu_integration/const.py
+++ b/custom_components/hcu_integration/const.py
@@ -122,6 +122,7 @@ SERVICE_ACTIVATE_ECO_MODE = "activate_eco_mode"
 SERVICE_DEACTIVATE_ABSENCE_MODE = "deactivate_absence_mode"
 SERVICE_SWITCH_ON_WITH_TIME = "switch_on_with_time"
 SERVICE_SEND_API_COMMAND = "send_api_command"
+SERVICE_SET_COOLING_MODE = "set_cooling_mode"
 SERVICE_USER_MESSAGE = "create_user_message_request"
 SERVICE_USER_MESSAGE_DELETE = "delete_user_message_request"
 
@@ -139,6 +140,7 @@ ATTR_END_TIME = "end_time"
 ATTR_ON_TIME = "on_time"
 ATTR_PATH = "path"
 ATTR_BODY = "body"
+ATTR_COOLING = "cooling"
 ATTR_USER_MESSAGE_ID = "userMessageId"
 ATTR_USER_MESSAGE_MESSAGE = "message"
 ATTR_USER_MESSAGE_TITLE = "title"
@@ -148,6 +150,7 @@ ATTR_USER_MESSAGE_CATEGORY = "messageCategory"
 # --- API Path Constants ---
 API_PATHS = {
     "ACTIVATE_ABSENCE_PERMANENT": "/hmip/home/heating/activateAbsencePermanent",
+    "SET_COOLING": "/hmip/home/heating/setCooling",
     "ACTIVATE_PARTY_MODE": "/hmip/group/heating/activatePartyMode",
     "ACTIVATE_VACATION": "/hmip/home/heating/activateVacation",
     "DEACTIVATE_ABSENCE": "/hmip/home/heating/deactivateAbsence",

--- a/custom_components/hcu_integration/icons.json
+++ b/custom_components/hcu_integration/icons.json
@@ -56,6 +56,7 @@
         "activate_eco_mode": "mdi:leaf",
         "deactivate_absence_mode": "mdi:home-account",
         "switch_on_with_time": "mdi:timer-outline",
+        "set_cooling_mode": "mdi:snowflake",
         "send_api_command": "mdi:api",
         "create_user_message_request": "mdi:message-badge",
         "delete_user_message_request": "mdi:message-off"

--- a/custom_components/hcu_integration/services.py
+++ b/custom_components/hcu_integration/services.py
@@ -261,6 +261,8 @@ async def async_handle_send_api_command(hass: HomeAssistant, call: ServiceCall) 
     except (HcuApiError, ConnectionError) as err:
         _LOGGER.error("Error calling send_api_command for path %s: %s", path, err)
     
+
+
 async def async_handle_set_cooling_mode(hass: HomeAssistant, call: ServiceCall) -> None:
     """Handle the set_cooling_mode service call."""
     cooling = call.data.get(ATTR_COOLING)

--- a/custom_components/hcu_integration/services.py
+++ b/custom_components/hcu_integration/services.py
@@ -15,6 +15,7 @@ from homeassistant.util import dt as dt_util
 
 from .api import HcuApiClient, HcuApiError
 from .const import (
+    ATTR_COOLING,
     ATTR_DURATION,
     ATTR_ENABLED,
     ATTR_END_TIME,
@@ -29,18 +30,20 @@ from .const import (
     ATTR_USER_MESSAGE_TITLE,
     ATTR_USER_MESSAGE_BEHAVIOR_TYPE,
     ATTR_USER_MESSAGE_CATEGORY,
+    API_PATHS,
     DOMAIN,
     SERVICE_ACTIVATE_ECO_MODE,
     SERVICE_ACTIVATE_PARTY_MODE,
     SERVICE_ACTIVATE_VACATION_MODE,
     SERVICE_DEACTIVATE_ABSENCE_MODE,
     SERVICE_PLAY_SOUND,
+    SERVICE_SET_COOLING_MODE,
     SERVICE_SET_RULE_STATE,
     SERVICE_SWITCH_ON_WITH_TIME,
     SERVICE_SEND_API_COMMAND,
     SERVICE_USER_MESSAGE,
     SERVICE_USER_MESSAGE_DELETE,
-    
+
 )
 
 if TYPE_CHECKING:
@@ -66,6 +69,7 @@ INTEGRATION_SERVICES = [
     SERVICE_DEACTIVATE_ABSENCE_MODE,
     SERVICE_SWITCH_ON_WITH_TIME,
     SERVICE_SEND_API_COMMAND,
+    SERVICE_SET_COOLING_MODE,
     SERVICE_USER_MESSAGE,
     SERVICE_USER_MESSAGE_DELETE,
 ]
@@ -257,6 +261,27 @@ async def async_handle_send_api_command(hass: HomeAssistant, call: ServiceCall) 
     except (HcuApiError, ConnectionError) as err:
         _LOGGER.error("Error calling send_api_command for path %s: %s", path, err)
     
+async def async_handle_set_cooling_mode(hass: HomeAssistant, call: ServiceCall) -> None:
+    """Handle the set_cooling_mode service call."""
+    cooling = call.data.get(ATTR_COOLING)
+
+    if not isinstance(cooling, bool):
+        _LOGGER.error("Required attribute '%s' must be a boolean for set_cooling_mode", ATTR_COOLING)
+        return
+
+    try:
+        client = _get_client_for_service(hass)
+        await client.async_send_api_command(
+            path=API_PATHS["SET_COOLING"],
+            body={ATTR_COOLING: cooling},
+        )
+        _LOGGER.info("Set cooling mode to %s", cooling)
+    except (HcuApiError, ConnectionError) as err:
+        _LOGGER.error("Error setting cooling mode: %s", err)
+    except ValueError as err:
+        _LOGGER.error("No HCU available: %s", err)
+
+
 def _as_multilang(value: Any, field_name: str) -> dict[str, str] | None:
     """Return value as multilingual dict.
 
@@ -346,6 +371,7 @@ def async_register_services(hass: HomeAssistant) -> None:
         SERVICE_DEACTIVATE_ABSENCE_MODE: async_handle_deactivate_absence_mode,
         SERVICE_SWITCH_ON_WITH_TIME: async_handle_switch_on_with_time,
         SERVICE_SEND_API_COMMAND: async_handle_send_api_command,
+        SERVICE_SET_COOLING_MODE: async_handle_set_cooling_mode,
         SERVICE_USER_MESSAGE: async_create_user_message_request,
         SERVICE_USER_MESSAGE_DELETE: async_delete_user_message_request,
     }

--- a/custom_components/hcu_integration/services.yaml
+++ b/custom_components/hcu_integration/services.yaml
@@ -170,6 +170,17 @@ switch_on_with_time:
           step: 0.1
           unit_of_measurement: "s"
           
+set_cooling_mode:
+  name: Set Cooling Mode
+  description: Activates or deactivates the system-wide cooling mode for all heating groups.
+  fields:
+    cooling:
+      name: Cooling
+      description: Set to true to activate cooling mode, false to deactivate it.
+      required: true
+      selector:
+        boolean:
+
 send_api_command:
   name: Send API Command
   description: Send a simple API command to the HCU. See EQ3's API documentation.

--- a/custom_components/hcu_integration/translations/de.json
+++ b/custom_components/hcu_integration/translations/de.json
@@ -253,6 +253,16 @@
                 }
             }
         },
+        "set_cooling_mode": {
+            "name": "Kühlmodus einstellen",
+            "description": "Aktiviert oder deaktiviert den systemweiten Kühlmodus für alle Heizgruppen.",
+            "fields": {
+                "cooling": {
+                    "name": "Kühlung",
+                    "description": "Auf true setzen, um den Kühlmodus zu aktivieren, auf false, um ihn zu deaktivieren."
+                }
+            }
+        },
         "send_api_command": {
             "name": "Sende API Befehl",
             "description": "Sende einen rohen API-Befehl an die HCU. Mit Vorsicht verwenden, da dies direkten Zugriff auf die API ermöglicht und bei falscher Verwendung unbeabsichtigte Nebeneffekte verursachen kann. Siehe API-Dokumentation von EQ3 für Details",

--- a/custom_components/hcu_integration/translations/en.json
+++ b/custom_components/hcu_integration/translations/en.json
@@ -253,6 +253,16 @@
                 }
             }
         },
+        "set_cooling_mode": {
+            "name": "Set Cooling Mode",
+            "description": "Activates or deactivates the system-wide cooling mode for all heating groups.",
+            "fields": {
+                "cooling": {
+                    "name": "Cooling",
+                    "description": "Set to true to activate cooling mode, false to deactivate it."
+                }
+            }
+        },
         "send_api_command": {
             "name": "Send API Command",
             "description": "Send a raw API command to the HCU. Use with caution, as this provides direct access to the API and can cause unintended side effects if used incorrectly. See EQ3's API documentation for details.",


### PR DESCRIPTION
## Description
Adds a new `set_cooling_mode` service that allows users to activate or deactivate cooling mode for all heating groups in the HCU system. This includes:

- New service handler `async_handle_set_cooling_mode` in services.py
- Service registration and configuration in services.yaml
- API path constant `SET_COOLING` pointing to `/hmip/home/heating/setCooling`
- Service attribute constant `ATTR_COOLING` for the boolean parameter
- Documentation in README.md with usage example
- Translations for English and German locales
- Service icon using snowflake emoji (mdi:snowflake)

## Motivation & Context
This change extends the HCU integration's capabilities to support cooling mode management, providing users with a convenient way to control system-wide cooling settings through Home Assistant automations and scripts.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation

## How Was It Tested?
- [x] Manually tested

## Checklist
- [x] Code follows the project style
- [x] Documentation updated
- [x] Translations added (EN, DE)

https://claude.ai/code/session_011Q6S4NouXyqRzpSdconViH