### PR TITLE
Preparing for HACS

### DIFF
--- a/custom_components/hcu_integration/__init__.py
+++ b/custom_components/hcu_integration/__init__.py
@@ -12,7 +12,7 @@ from typing import Any, cast
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_TOKEN, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -47,6 +47,8 @@ from . import event
 _LOGGER = logging.getLogger(__name__)
 
 type HcuData = dict[str, "HcuCoordinator"]
+
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 SERVICE_ENTRIES_KEY = f"{DOMAIN}_service_entries"
 

--- a/custom_components/hcu_integration/const.py
+++ b/custom_components/hcu_integration/const.py
@@ -127,8 +127,8 @@ SERVICE_USER_MESSAGE = "create_user_message_request"
 SERVICE_USER_MESSAGE_DELETE = "delete_user_message_request"
 
 # --- Preset Constants ---
-PRESET_ECO = "Eco"
-PRESET_PARTY = "Party"
+PRESET_ECO = "eco"
+PRESET_PARTY = "party"
 
 # --- Service Attribute Constants ---
 ATTR_SOUND_FILE = "sound_file"
@@ -141,11 +141,11 @@ ATTR_ON_TIME = "on_time"
 ATTR_PATH = "path"
 ATTR_BODY = "body"
 ATTR_COOLING = "cooling"
-ATTR_USER_MESSAGE_ID = "userMessageId"
+ATTR_USER_MESSAGE_ID = "user_message_id"
 ATTR_USER_MESSAGE_MESSAGE = "message"
 ATTR_USER_MESSAGE_TITLE = "title"
-ATTR_USER_MESSAGE_BEHAVIOR_TYPE = "behaviorType"
-ATTR_USER_MESSAGE_CATEGORY = "messageCategory"
+ATTR_USER_MESSAGE_BEHAVIOR_TYPE = "behavior_type"
+ATTR_USER_MESSAGE_CATEGORY = "message_category"
 
 # --- API Path Constants ---
 API_PATHS = {

--- a/custom_components/hcu_integration/icons.json
+++ b/custom_components/hcu_integration/icons.json
@@ -22,8 +22,8 @@
                         "default": "mdi:thermostat",
                         "state": {
                             "boost": "mdi:rocket-launch",
-                            "Eco": "mdi:leaf",
-                            "Party": "mdi:party-popper"
+                            "eco": "mdi:leaf",
+                            "party": "mdi:party-popper"
                         }
                     }
                 }

--- a/custom_components/hcu_integration/services.yaml
+++ b/custom_components/hcu_integration/services.yaml
@@ -271,7 +271,7 @@ delete_user_message_request:
   description: Delete a previously created User Message from the Homematic IP app.
   fields:
     user_message_id:
-      name: User Message Id
+      name: User Message ID
       description: "Use the User Message ID of the previously created User Message here."
       example: 'USER_MESSAGE'
       required: true

--- a/custom_components/hcu_integration/services.yaml
+++ b/custom_components/hcu_integration/services.yaml
@@ -207,7 +207,7 @@ create_user_message_request:
   name: Create User Message
   description: Create a User Message that is displayed in the Homematic IP app. See the EQ3 API documentation for details.
   fields:
-    messageCategory:
+    message_category:
       required: true
       name: Message Category
       description: Select the category of the user message.
@@ -223,7 +223,7 @@ create_user_message_request:
               value: ERROR
             - label: WARN
               value: WARN
-    userMessageId:
+    user_message_id:
       required: true
       name: User Message ID
       description: Enter a unique identifier for the user message.
@@ -247,7 +247,7 @@ create_user_message_request:
       example: "Text"
       selector:
         text:
-    behaviorType:
+    behavior_type:
       required: true
       name: Behavior Type
       description: Select how the message can be acknowledged or dismissed in the Homematic IP app.
@@ -270,7 +270,7 @@ delete_user_message_request:
   name: Delete a User Message
   description: Delete a previously created User Message from the Homematic IP app.
   fields:
-    userMessageId:
+    user_message_id:
       name: User Message Id
       description: "Use the User Message ID of the previously created User Message here."
       example: 'USER_MESSAGE'

--- a/custom_components/hcu_integration/translations/de.json
+++ b/custom_components/hcu_integration/translations/de.json
@@ -307,7 +307,7 @@
             "description": "Lösche eine Zuvor erstelle User Message Nachricht aus der Homematic IP App. Siehe API-Dokumentation von EQ3 für Details",
             "fields": {
                 "user_message_id": {
-                    "name": "User Message Id",
+                    "name": "User Message ID",
                     "description": "Verwende hier die User Message ID der zurvor angelegten User Message."
                 }
             }

--- a/custom_components/hcu_integration/translations/de.json
+++ b/custom_components/hcu_integration/translations/de.json
@@ -319,6 +319,8 @@
                 "state_attributes": {
                     "preset_mode": {
                         "state": {
+                            "boost": "Boost",
+                            "eco": "Eco",
                             "party": "Party"
                         }
                     }

--- a/custom_components/hcu_integration/translations/de.json
+++ b/custom_components/hcu_integration/translations/de.json
@@ -314,6 +314,17 @@
         }
     },
     "entity": {
+        "climate": {
+            "hcu_climate": {
+                "state_attributes": {
+                    "preset_mode": {
+                        "state": {
+                            "party": "Party"
+                        }
+                    }
+                }
+            }
+        },
         "button": {
             "hcu_device_identify":{
                 "name": "Identifizieren"

--- a/custom_components/hcu_integration/translations/de.json
+++ b/custom_components/hcu_integration/translations/de.json
@@ -117,7 +117,6 @@
     "issues": {
 		"pin_failed": {
 			"title": "PIN-Fehler für {device_name}",
-			"description": "Der Autorisierungs-PIN für {device_name} ist fehlgeschlagen.",
 			"fix_flow": {
 				"step": {
 					"confirm": {
@@ -281,11 +280,11 @@
           "name": "User Message erstellen",
           "description": "Erstellt eine User Message, die in der Homematic IP App angezeigt wird. Siehe die eQ-3 API-Dokumentation für Details.",
           "fields": {
-            "messageCategory": {
+            "message_category": {
               "name": "User Message Kategorie",
               "description": "Wähle die Kategorie der User Message."
             },
-            "userMessageId": {
+            "user_message_id": {
               "name": "User Message ID",
               "description": "Gib eine eindeutige Kennung für die User Message an."
             },
@@ -297,7 +296,7 @@
               "name": "Nachricht",
               "description": "Gib einen Nachrichtentext ein. Es kann entweder ein Text oder ein Language Object sein."
             },
-            "behaviorType": {
+            "behavior_type": {
               "name": "Verhaltenstyp",
               "description": "Lege fest, wie die Nachricht in der Homematic IP App bestätigt oder ausgeblendet werden kann."
             }
@@ -307,7 +306,7 @@
             "name": "Lösche eine User Message Nachricht",
             "description": "Lösche eine Zuvor erstelle User Message Nachricht aus der Homematic IP App. Siehe API-Dokumentation von EQ3 für Details",
             "fields": {
-                "userMessageId": {
+                "user_message_id": {
                     "name": "User Message Id",
                     "description": "Verwende hier die User Message ID der zurvor angelegten User Message."
                 }

--- a/custom_components/hcu_integration/translations/en.json
+++ b/custom_components/hcu_integration/translations/en.json
@@ -319,6 +319,8 @@
                 "state_attributes": {
                     "preset_mode": {
                         "state": {
+                            "boost": "Boost",
+                            "eco": "Eco",
                             "party": "Party"
                         }
                     }

--- a/custom_components/hcu_integration/translations/en.json
+++ b/custom_components/hcu_integration/translations/en.json
@@ -314,6 +314,17 @@
         }
     },
     "entity": {
+        "climate": {
+            "hcu_climate": {
+                "state_attributes": {
+                    "preset_mode": {
+                        "state": {
+                            "party": "Party"
+                        }
+                    }
+                }
+            }
+        },
         "button": {
             "hcu_device_identify":{
                 "name": "Identify"

--- a/custom_components/hcu_integration/translations/en.json
+++ b/custom_components/hcu_integration/translations/en.json
@@ -117,7 +117,6 @@
     "issues": {
 		"pin_failed": {
 			"title": "PIN failed for {device_name}",
-			"description": "The authorization PIN for {device_name} failed.",
 			"fix_flow": {
 				"step": {
 					"confirm": {
@@ -281,11 +280,11 @@
           "name": "Create a User Message",
           "description": "Creates a user message that is displayed in the Homematic IP app. See the eQ-3 API documentation for details.",
           "fields": {
-            "messageCategory": {
+            "message_category": {
               "name": "Message Category",
               "description": "Select the category of the user message."
             },
-            "userMessageId": {
+            "user_message_id": {
               "name": "User Message ID",
               "description": "Enter a unique identifier for the user message."
             },
@@ -297,7 +296,7 @@
               "name": "Message",
               "description": "The message can be a string or an object with language keys."
             },
-            "behaviorType": {
+            "behavior_type": {
               "name": "Behavior Type",
               "description": "Select how the message can be acknowledged or dismissed in the Homematic IP app."
             }
@@ -307,7 +306,7 @@
             "name": "Delete a User Message",
             "description": "Delete a previously created User Message from the Homematic IP app. See the EQ3 API documentation for details.",
             "fields": {
-                "userMessageId": {
+                "user_message_id": {
                     "name": "User Message ID",
                     "description": "Use the User Message ID of the previously created User Message here."
                 }


### PR DESCRIPTION
## Description
This PR standardizes naming conventions across the integration by converting camelCase attribute names to snake_case, which is the Python standard. Changes include:

- Updated preset constants (`PRESET_ECO`, `PRESET_PARTY`) to lowercase values
- Converted service attribute constants to snake_case (`userMessageId` → `user_message_id`, `behaviorType` → `behavior_type`, `messageCategory` → `message_category`)
- Updated all references in service definitions, translations, and icon configurations
- Added missing `config_validation` import and `CONFIG_SCHEMA` definition in `__init__.py`
- Removed redundant description field from PIN failed issue in translations

## Motivation & Context
This change improves code consistency and follows Python naming conventions (PEP 8). Snake_case is the standard for Python identifiers and Home Assistant service attributes, making the codebase more maintainable and aligned with community standards.

## Type of Change
- [x] Breaking change
- [x] Code style/refactoring

## How Was It Tested?
- Code review of naming consistency across all files
- Verified all references updated in parallel (const.py, services.yaml, translations, icons.json)

## Checklist
- [x] Code follows the project style
- [x] Documentation updated (translations and service definitions)
- [x] All references updated consistently

https://claude.ai/code/session_01GMNJTLj3riivvnXKcApy1E