### PR TITLE
fix(lock): show locking transition state immediately on button press

### DIFF
--- a/custom_components/hcu_integration/lock.py
+++ b/custom_components/hcu_integration/lock.py
@@ -1,6 +1,6 @@
 # custom_components/hcu_integration/lock.py
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 import json
 
 from homeassistant.components.lock import LockEntity, LockEntityFeature
@@ -67,6 +67,10 @@ class HcuLock(HcuBaseEntity, LockEntity):
         # Track if this specific lock has determined it requires a PIN
         self._pin_required: bool | None = None
 
+        # Optimistic transition flags for immediate UI feedback
+        self._optimistic_is_locking: bool = False
+        self._optimistic_is_unlocking: bool = False
+
         # Log available channel data fields for diagnostics
         _LOGGER.debug(
             "Lock '%s' initialized with channel data fields: %s",
@@ -82,6 +86,8 @@ class HcuLock(HcuBaseEntity, LockEntity):
     @property
     def is_locking(self) -> bool | None:
         """Return true if the lock is locking."""
+        if self._optimistic_is_locking:
+            return True
         motor_state = self._channel.get("motorState")
         lock_state = self._channel.get("lockState")
 
@@ -89,12 +95,13 @@ class HcuLock(HcuBaseEntity, LockEntity):
         if motor_state is None and lock_state is None:
             return None
 
-        # Return True/False based on actual state comparison
         return motor_state == MOTOR_STATE_LOCKING or lock_state == MOTOR_STATE_LOCKING
 
     @property
     def is_unlocking(self) -> bool | None:
         """Return true if the lock is unlocking."""
+        if self._optimistic_is_unlocking:
+            return True
         motor_state = self._channel.get("motorState")
         lock_state = self._channel.get("lockState")
 
@@ -102,7 +109,6 @@ class HcuLock(HcuBaseEntity, LockEntity):
         if motor_state is None and lock_state is None:
             return None
 
-        # Return True/False based on actual state comparison
         return motor_state == MOTOR_STATE_UNLOCKING or lock_state == MOTOR_STATE_UNLOCKING
 
     @property
@@ -175,6 +181,12 @@ class HcuLock(HcuBaseEntity, LockEntity):
 
         return attrs
 
+    def _handle_coordinator_update(self) -> None:
+        """Clear optimistic transition flags and let actual device state take over."""
+        self._optimistic_is_locking = False
+        self._optimistic_is_unlocking = False
+        super()._handle_coordinator_update()
+
     async def _set_lock_state(self, state: str) -> None:
         """Send the command to set the lock state."""
         pin = self._config_entry.data.get(CONF_PIN)
@@ -184,7 +196,11 @@ class HcuLock(HcuBaseEntity, LockEntity):
             self.name, state, self._channel_index, self._device_id
         )
 
-        # Use optimistic state updates for immediate UI feedback
+        # Set optimistic transition flags for immediate UI feedback before the API call.
+        # is_locking/is_unlocking read these flags first so the slider reacts instantly.
+        # The flags are cleared in _handle_coordinator_update() when the device reports back.
+        self._optimistic_is_locking = state == LOCK_STATE_LOCKED
+        self._optimistic_is_unlocking = state == LOCK_STATE_UNLOCKED
         self._attr_assumed_state = True
         self.async_write_ha_state()
 
@@ -200,7 +216,7 @@ class HcuLock(HcuBaseEntity, LockEntity):
 
         except HcuApiError as err:
             err_type = handle_lock_api_error(err, self.name, pin)
-            
+
             if err_type == "invalid_pin":
                 self._pin_required = True
                 if pin:
@@ -208,14 +224,20 @@ class HcuLock(HcuBaseEntity, LockEntity):
             elif not err_type:
                 _LOGGER.error("Failed to set lock state for %s: %s", self.name, err)
 
+            # Revert optimistic state on error
+            self._optimistic_is_locking = False
+            self._optimistic_is_unlocking = False
+            self._attr_assumed_state = False
+            self.async_write_ha_state()
+
         except ConnectionError as err:
             _LOGGER.error(
                 "Connection failed while setting lock state for %s: %s", self.name, err
             )
 
-        finally:
-            # Reset assumed state to let coordinator updates provide actual state
-            # The coordinator will update the entity state based on WebSocket events
+            # Revert optimistic state on error
+            self._optimistic_is_locking = False
+            self._optimistic_is_unlocking = False
             self._attr_assumed_state = False
             self.async_write_ha_state()
 


### PR DESCRIPTION
When clicking "Lock", the HA slider now shows the "locking in progress"
animation instantly instead of staying at unlocked until the physical
device reports back.

Two bugs were fixed:
1. The optimistic async_write_ha_state() call was useless because
   is_locking/is_unlocking still read stale channel data. New optimistic
   flags (_optimistic_is_locking/_optimistic_is_unlocking) are now set
   before the API call and checked first in the properties.
2. The finally block fired after the HTTP response (before the WebSocket
   event), causing a brief flash back to the old state. Replaced with
   explicit revert in except blocks; _handle_coordinator_update() clears
   the flags when real device state arrives.

https://claude.ai/code/session_013H4p5rqxY2ft9kbgBaHBBH