### PR TITLE
fix(lock): Schieber zeigt Abschließen-Übergang sofort

### DIFF
--- a/custom_components/hcu_integration/lock.py
+++ b/custom_components/hcu_integration/lock.py
@@ -190,8 +190,9 @@ class HcuLock(HcuAccessMixin, HcuBaseEntity, LockEntity):
 
     def _handle_coordinator_update(self) -> None:
         """Clear optimistic transition flags and let actual device state take over."""
-        self._optimistic_is_locking = False
-        self._optimistic_is_unlocking = False
+        if self._device_id in self.coordinator.data:
+            self._optimistic_is_locking = False
+            self._optimistic_is_unlocking = False
         super()._handle_coordinator_update()
 
     async def _set_lock_state(self, state: str, pin: str | None = None) -> None:

--- a/custom_components/hcu_integration/lock.py
+++ b/custom_components/hcu_integration/lock.py
@@ -71,6 +71,10 @@ class HcuLock(HcuAccessMixin, HcuBaseEntity, LockEntity):
         # Track if this specific lock has determined it requires a PIN
         self._pin_required: bool | None = None
 
+        # Optimistic transition flags for immediate UI feedback
+        self._optimistic_is_locking: bool = False
+        self._optimistic_is_unlocking: bool = False
+
         # Log available channel data fields for diagnostics
         _LOGGER.debug(
             "Lock '%s' initialized with channel data fields: %s",
@@ -86,6 +90,8 @@ class HcuLock(HcuAccessMixin, HcuBaseEntity, LockEntity):
     @property
     def is_locking(self) -> bool | None:
         """Return true if the lock is locking."""
+        if self._optimistic_is_locking:
+            return True
         motor_state = self._channel.get("motorState")
         lock_state = self._channel.get("lockState")
 
@@ -99,6 +105,8 @@ class HcuLock(HcuAccessMixin, HcuBaseEntity, LockEntity):
     @property
     def is_unlocking(self) -> bool | None:
         """Return true if the lock is unlocking."""
+        if self._optimistic_is_unlocking:
+            return True
         motor_state = self._channel.get("motorState")
         lock_state = self._channel.get("lockState")
 
@@ -180,6 +188,12 @@ class HcuLock(HcuAccessMixin, HcuBaseEntity, LockEntity):
 
         return attrs
 
+    def _handle_coordinator_update(self) -> None:
+        """Clear optimistic transition flags and let actual device state take over."""
+        self._optimistic_is_locking = False
+        self._optimistic_is_unlocking = False
+        super()._handle_coordinator_update()
+
     async def _set_lock_state(self, state: str, pin: str | None = None) -> None:
         """Send the command to set the lock state."""
 
@@ -188,7 +202,11 @@ class HcuLock(HcuAccessMixin, HcuBaseEntity, LockEntity):
             self.name, state, self._channel_index, self._device_id
         )
 
-        # Use optimistic state updates for immediate UI feedback
+        # Set optimistic transition flags for immediate UI feedback before the API call.
+        # is_locking/is_unlocking read these flags first so the slider reacts instantly.
+        # The flags are cleared in _handle_coordinator_update() when the device reports back.
+        self._optimistic_is_locking = state == LOCK_STATE_LOCKED
+        self._optimistic_is_unlocking = state == LOCK_STATE_UNLOCKED
         self._attr_assumed_state = True
         self.async_write_ha_state()
 
@@ -204,7 +222,7 @@ class HcuLock(HcuAccessMixin, HcuBaseEntity, LockEntity):
 
         except HcuApiError as err:
             err_type = handle_lock_api_error(err, self.name, pin)
-            
+
             if err_type == "invalid_pin":
                 self._pin_required = True
                 ir.async_create_issue(
@@ -223,14 +241,20 @@ class HcuLock(HcuAccessMixin, HcuBaseEntity, LockEntity):
             elif not err_type:
                 _LOGGER.error("Failed to set lock state for %s: %s", self.name, err)
 
+            # Revert optimistic state on error
+            self._optimistic_is_locking = False
+            self._optimistic_is_unlocking = False
+            self._attr_assumed_state = False
+            self.async_write_ha_state()
+
         except ConnectionError as err:
             _LOGGER.error(
                 "Connection failed while setting lock state for %s: %s", self.name, err
             )
 
-        finally:
-            # Reset assumed state to let coordinator updates provide actual state
-            # The coordinator will update the entity state based on WebSocket events
+            # Revert optimistic state on error
+            self._optimistic_is_locking = False
+            self._optimistic_is_unlocking = False
             self._attr_assumed_state = False
             self.async_write_ha_state()
 


### PR DESCRIPTION
## Problem

Beim Klick auf „Abschließen" sprang der HA-Schieber nicht sofort in den Übergangszustand (Fahrtrichtung). Er blieb auf „entsperrt" stehen, bis das physische Gerät die Aktion abgeschlossen und zurückgemeldet hatte. Der Nutzer sah keinen Übergang – der Schieber sprang ohne Vorwarnung direkt auf „abgeschlossen".

Beim Aufschließen war der Fahrtrichtungs-Zustand hingegen sichtbar, weil das Gerät in diesem Fall schnell ein `motorState = MOTOR_STATE_UNLOCKING`-WebSocket-Event sendet.

## Ursache (zwei Bugs in `lock.py`)

**Bug 1 – Optimistischer `async_write_ha_state()`-Aufruf zeigte keinen Effekt**

`is_locking` und `is_unlocking` sind als `@property` implementiert und lesen direkt aus `self._channel` (den Gerätedaten). Bevor das Gerät reagiert, sind diese unverändert → `is_locking` gibt `False` zurück. Der `async_write_ha_state()`-Aufruf vor dem API-Call war daher wirkungslos.

**Bug 2 – `finally`-Block verursachte kurzen Rücksprung zum alten Zustand**

```python
finally:
    self._attr_assumed_state = False
    self.async_write_ha_state()   # feuerte sofort nach HTTP-Antwort
```

Der `finally`-Block feuerte sofort nach der HTTP-Antwort des API-Aufrufs – bevor WebSocket-Events vom Gerät ankamen. Die Kanaldaten zeigten noch den alten Zustand → die UI sprang kurz zurück auf „entsperrt", bevor dann das LOCKING-Event ankam.

## Lösung

- **Optimistische Flags** `_optimistic_is_locking` / `_optimistic_is_unlocking` werden **vor** dem API-Aufruf gesetzt
- `is_locking` / `is_unlocking` prüfen diese Flags zuerst → sofortiges `True` ohne auf Gerätedaten zu warten
- **Kein `finally`-Block** mehr – stattdessen explizite Rücksetzung nur in den `except`-Blöcken bei Fehler
- Neues `_handle_coordinator_update()` in `HcuLock` löscht die Flags, wenn echter Gerätestatus via WebSocket ankommt

## Verhalten nach dem Fix

1. Klick auf „Abschließen" → Schieber zeigt **sofort** Fahrtrichtungs-Zustand
2. Gerät meldet `motorState = MOTOR_STATE_LOCKING` → Zustand bleibt konsistent
3. Gerät meldet `lockState = LOCK_STATE_LOCKED` → Schieber zeigt „abgeschlossen"
4. Bei API-Fehler → Schieber springt sofort zurück (Rollback in `except`)

---
_Generated by [Claude Code](https://claude.ai/code/session_013H4p5rqxY2ft9kbgBaHBBH)_