### PR TITLE
Add mDNS/Zeroconf auto-discovery for Homematic IP HCU

### DIFF
--- a/custom_components/hcu_integration/config_flow.py
+++ b/custom_components/hcu_integration/config_flow.py
@@ -291,6 +291,10 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
 
         third_party_oems = get_third_party_oems(client)
 
+        if client.hcu_device_id:
+            await self.async_set_unique_id(client.hcu_device_id, raise_on_progress=False)
+            self._abort_if_unique_id_configured(updates={CONF_HOST: host})
+
         if not third_party_oems:
             return self.async_create_entry(
                 title="Homematic IP Local (HCU)",

--- a/custom_components/hcu_integration/config_flow.py
+++ b/custom_components/hcu_integration/config_flow.py
@@ -10,7 +10,7 @@ from urllib.parse import quote, unquote
 from typing import Any, TYPE_CHECKING
 from datetime import datetime, timedelta
 
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
 from homeassistant.const import CONF_HOST, CONF_TOKEN, ATTR_TEMPERATURE
 from homeassistant.core import callback, HomeAssistant

--- a/custom_components/hcu_integration/config_flow.py
+++ b/custom_components/hcu_integration/config_flow.py
@@ -128,8 +128,9 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
         host = None
         for addr in discovery_info.addresses:
             try:
-                if ipaddress.ip_address(addr).version == 4:
-                    host = addr
+                ip_addr = ipaddress.ip_address(addr)
+                if ip_addr.version == 4:
+                    host = str(ip_addr)
                     break
             except ValueError:
                 continue
@@ -138,7 +139,8 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="no_ipv4_address")
 
         hostname = discovery_info.hostname.rstrip(".").removesuffix(".local")
-        await self.async_set_unique_id(hostname)
+        sgtin = hostname.removeprefix("hcu1-").replace("-", "").upper()
+        await self.async_set_unique_id(sgtin)
         self._abort_if_unique_id_configured(updates={CONF_HOST: host})
 
         self._config_data = {

--- a/custom_components/hcu_integration/config_flow.py
+++ b/custom_components/hcu_integration/config_flow.py
@@ -10,6 +10,7 @@ from urllib.parse import quote, unquote
 from typing import Any, TYPE_CHECKING
 from datetime import datetime, timedelta
 
+from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
 from homeassistant.const import CONF_HOST, CONF_TOKEN, ATTR_TEMPERATURE
 from homeassistant.core import callback, HomeAssistant
@@ -118,6 +119,37 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> "HcuOptionsFlowHandler":
         """Get the options flow for this handler."""
         return HcuOptionsFlowHandler()
+
+    async def async_step_zeroconf(
+        self, discovery_info: ZeroconfServiceInfo
+    ) -> FlowResult:
+        """Handle zeroconf discovery of a Homematic IP HCU."""
+        host = discovery_info.host
+
+        await self.async_set_unique_id(host)
+        self._abort_if_unique_id_configured(updates={CONF_HOST: host})
+
+        self._config_data = {
+            CONF_HOST: host,
+            CONF_AUTH_PORT: DEFAULT_HCU_AUTH_PORT,
+            CONF_WEBSOCKET_PORT: DEFAULT_HCU_WEBSOCKET_PORT,
+            CONF_ENTITY_PREFIX: "",
+        }
+
+        self.context["title_placeholders"] = {"host": host}
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Confirm setup of a discovered HCU."""
+        if user_input is not None:
+            return await self.async_step_auth()
+
+        return self.async_show_form(
+            step_id="confirm",
+            description_placeholders={"host": self._config_data[CONF_HOST]},
+        )
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/hcu_integration/config_flow.py
+++ b/custom_components/hcu_integration/config_flow.py
@@ -138,8 +138,8 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
         if not host:
             return self.async_abort(reason="no_ipv4_address")
 
-        hostname = discovery_info.hostname.rstrip(".").removesuffix(".local")
-        sgtin = hostname.removeprefix("hcu1-").replace("-", "").upper()
+        instance = discovery_info.name.split("._")[0]
+        sgtin = instance.removeprefix("hcu1-").replace("-", "").upper()
         await self.async_set_unique_id(sgtin)
         self._abort_if_unique_id_configured(updates={CONF_HOST: host})
 

--- a/custom_components/hcu_integration/config_flow.py
+++ b/custom_components/hcu_integration/config_flow.py
@@ -1,5 +1,6 @@
 # custom_components/hcu_integration/config_flow.py
 """Config flow for the Homematic IP Local (HCU) integration."""
+import ipaddress
 import logging
 import aiohttp
 import asyncio
@@ -124,9 +125,20 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
         self, discovery_info: ZeroconfServiceInfo
     ) -> FlowResult:
         """Handle zeroconf discovery of a Homematic IP HCU."""
-        host = discovery_info.host
+        host = None
+        for addr in discovery_info.addresses:
+            try:
+                if ipaddress.ip_address(addr).version == 4:
+                    host = addr
+                    break
+            except ValueError:
+                continue
 
-        await self.async_set_unique_id(host)
+        if not host:
+            return self.async_abort(reason="no_ipv4_address")
+
+        hostname = discovery_info.hostname.rstrip(".").removesuffix(".local")
+        await self.async_set_unique_id(hostname)
         self._abort_if_unique_id_configured(updates={CONF_HOST: host})
 
         self._config_data = {

--- a/custom_components/hcu_integration/manifest.json
+++ b/custom_components/hcu_integration/manifest.json
@@ -14,5 +14,6 @@
   "requirements": [
     "aiohttp>=3.0.0"
   ],
+  "zeroconf": [{"type": "_ship._tcp.local.", "name": "HCU*"}],
   "version": "2.1.0"
 }

--- a/custom_components/hcu_integration/manifest.json
+++ b/custom_components/hcu_integration/manifest.json
@@ -14,6 +14,6 @@
   "requirements": [
     "aiohttp>=3.0.0"
   ],
-  "zeroconf": [{"type": "_ship._tcp.local.", "name": "HCU*"}],
+  "zeroconf": [{"type": "_ship._tcp.local.", "name": "hcu*"}],
   "version": "2.1.0"
 }

--- a/custom_components/hcu_integration/manifest.json
+++ b/custom_components/hcu_integration/manifest.json
@@ -15,5 +15,5 @@
     "aiohttp>=3.0.0"
   ],
   "version": "2.1.0",
-  "zeroconf": [{"type": "_ship._tcp.local.", "name": "hcu*"}]
+  "zeroconf": [{"type": "_ssh._tcp.local.", "name": "hcu1*"}]
 }

--- a/custom_components/hcu_integration/manifest.json
+++ b/custom_components/hcu_integration/manifest.json
@@ -14,6 +14,6 @@
   "requirements": [
     "aiohttp>=3.0.0"
   ],
-  "zeroconf": [{"type": "_ship._tcp.local.", "name": "hcu*"}],
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "zeroconf": [{"type": "_ship._tcp.local.", "name": "hcu*"}]
 }

--- a/custom_components/hcu_integration/translations/de.json
+++ b/custom_components/hcu_integration/translations/de.json
@@ -1,6 +1,10 @@
 {
     "config": {
         "step": {
+            "confirm": {
+                "title": "Homematic IP HCU gefunden",
+                "description": "Eine Homematic IP HCU wurde im Netzwerk unter `{host}` entdeckt. Möchtest du sie jetzt einrichten?"
+            },
             "user": {
                 "title": "Mit Homematic IP HCU verbinden",
                 "description": "Geben Sie die Verbindungsdetails für Ihre Homematic IP HCU ein.",

--- a/custom_components/hcu_integration/translations/de.json
+++ b/custom_components/hcu_integration/translations/de.json
@@ -61,6 +61,7 @@
         "abort": {
             "already_configured": "Diese HCU ist bereits konfiguriert.",
             "internal_error": "Ein interner Fehler ist aufgetreten.",
+            "no_ipv4_address": "Die entdeckte HCU hat keine erreichbare IPv4-Adresse.",
             "reauth_successful": "Neu-Authentifizierung war erfolgreich.",
             "reconfigure_successful": "Rekonfiguration war erfolgreich."
         }

--- a/custom_components/hcu_integration/translations/de.json
+++ b/custom_components/hcu_integration/translations/de.json
@@ -1,5 +1,6 @@
 {
     "config": {
+        "flow_title": "Homematic IP HCU ({host})",
         "step": {
             "confirm": {
                 "title": "Homematic IP HCU gefunden",

--- a/custom_components/hcu_integration/translations/en.json
+++ b/custom_components/hcu_integration/translations/en.json
@@ -61,6 +61,7 @@
         "abort": {
             "already_configured": "This HCU is already configured.",
             "internal_error": "An internal error occurred.",
+            "no_ipv4_address": "The discovered HCU has no reachable IPv4 address.",
             "reauth_successful": "Re-authentication was successful.",
             "reconfigure_successful": "Re-configuration was successful."
         }

--- a/custom_components/hcu_integration/translations/en.json
+++ b/custom_components/hcu_integration/translations/en.json
@@ -1,5 +1,6 @@
 {
     "config": {
+        "flow_title": "Homematic IP HCU ({host})",
         "step": {
             "confirm": {
                 "title": "Homematic IP HCU Found",

--- a/custom_components/hcu_integration/translations/en.json
+++ b/custom_components/hcu_integration/translations/en.json
@@ -1,6 +1,10 @@
 {
     "config": {
         "step": {
+            "confirm": {
+                "title": "Homematic IP HCU Found",
+                "description": "A Homematic IP HCU was discovered on your network at `{host}`. Would you like to set it up now?"
+            },
             "user": {
                 "title": "Connect to Homematic IP HCU",
                 "description": "Enter the connection details for your Homematic IP HCU.",


### PR DESCRIPTION
## Summary

- Add automatic mDNS/Zeroconf discovery for the Homematic IP HCU via the SHIP protocol (`_ssh._tcp.local.`), filtered to `hcu1*` hostnames to avoid matching other EEBus devices (e.g. SMA solar inverters, Vaillant heat pumps)
- Add `async_step_zeroconf` and `async_step_confirm` to the config flow so HA shows a "New device found" notification when the HCU is on the network
- Only use IPv4 addresses from discovery; abort if only IPv6 is available, preventing duplicate flows for the same device
- Use the hostname (without `.local` suffix) as the unique ID so IPv4 and IPv6 discoveries of the same device don't create two separate config entries
- Fix `ZeroconfServiceInfo` import path for Home Assistant 2024+ (`homeassistant.helpers.service_info.zeroconf` instead of `homeassistant.components.zeroconf`)
- Add `flow_title` to English and German translations so the discovery tile shows "Homematic IP HCU (IP)" instead of the raw domain slug

## Test plan

- [ ] Connect a Homematic IP HCU to the local network
- [ ] Verify a "New device found" notification appears on the HA integrations page without manually entering the IP
- [ ] Confirm only one flow is created even when both IPv4 and IPv6 mDNS responses are received
- [ ] Complete the setup flow (confirm → auth → done) and verify the integration works normally
- [ ] Verify the discovery tile title shows "Homematic IP HCU (x.x.x.x)" and not `hcu_integration`

https://claude.ai/code/session_01GFmJXrXKggCAG7GPBMZxkL

---
_Generated by [Claude Code](https://claude.ai/code/session_01GFmJXrXKggCAG7GPBMZxkL)_