### PR TITLE
feat: App User confirmation via async_show_progress + HA instance name as device name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,14 @@ All notable changes to the Homematic IP Local (HCU) integration will be document
 
 ## 2.1.0-beta3 - 2026-06
 
-### 🔧 UI Improvements
+### ✨ Improvements
 
+- **App User Setup: Automatic System Button Detection** — The manual confirmation step ("Have you pressed the button?") has been removed. The integration now automatically waits for the system button press on the HCU and proceeds once detected. If the button is not pressed within 60 seconds, the flow is aborted with a clear error message. Applies to both initial setup and reconfiguration.
+- **Device Name on Registration** — App User and Plugin User are now registered using the Home Assistant instance name (e.g. *"Home"*). For Plugin User, the current timestamp is appended to keep multiple registrations distinguishable (e.g. *"Home - 15.06.2026 14:20"*).
+
+### 🐛 Bug Fixes
+
+- Fixed reconfiguration not automatically reloading the integration when it was previously in an error state (`SETUP_ERROR`/`SETUP_RETRY`).
 - Several small UI text fixes in the App User setup and reconfigure flow: removed the misleading System PIN hint, corrected the confirm button label to **"OK"**, and replaced all references to "blue button" with the correct term **"system button"** / **"Systemtaste"**.
 
 ---

--- a/custom_components/hcu_integration/config_flow.py
+++ b/custom_components/hcu_integration/config_flow.py
@@ -14,7 +14,7 @@ from typing import Any, TYPE_CHECKING
 from datetime import datetime, timedelta
 
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
-from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState, ConfigFlow, OptionsFlow
 from homeassistant.const import CONF_HOST, ATTR_TEMPERATURE
 from homeassistant.core import callback, HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
@@ -319,26 +319,9 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_show_progress_done(next_step_id="button_timeout")
 
         self._confirm_task = None
-        session = aiohttp_client.async_get_clientsession(self.hass)
-        ssl_context = await create_unverified_ssl_context(self.hass)
-        try:
-            new_token = await self._async_request_app_auth_token(
-                session, host, HCU_REST_PORT, self._app_client_id,
-                self._app_client_auth, self._app_access_point_id, ssl_context,
-            )
-            new_client_id = await self._async_confirm_app_auth_token(
-                session, host, HCU_REST_PORT, self._app_client_id,
-                self._app_client_auth, new_token, self._app_access_point_id, ssl_context,
-            )
-        except Exception as exc:
-            _LOGGER.error("Failed to fetch App User token after button press: %s", exc)
-            return self.async_show_progress_done(next_step_id="button_timeout")
-
-        self._app_new_token = new_token
-        self._app_new_client_id = new_client_id
-        self._config_data[CONF_APP_TOKEN] = new_token
+        self._config_data[CONF_APP_TOKEN] = self._app_new_token
         self._config_data[CONF_HCU_SGTIN] = self._app_access_point_id
-        self._config_data[CONF_APP_CLIENT_ID] = new_client_id
+        self._config_data[CONF_APP_CLIENT_ID] = self._app_new_client_id
 
         if self._is_dual_setup:
             return self.async_show_progress_done(next_step_id="auth")
@@ -580,7 +563,7 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
                     updated_data.pop(CONF_APP_TOKEN, None)
                     updated_data.pop(CONF_APP_CLIENT_ID, None)
                     updated_data.pop(CONF_HCU_SGTIN, None)
-                self.hass.config_entries.async_update_entry(entry, data=updated_data)
+                self._update_entry_and_reload_if_needed(entry, updated_data)
                 return self.async_abort(reason="reconfigure_successful")
 
             except aiohttp.ClientResponseError as err:
@@ -725,7 +708,7 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
                 return await self.async_step_reconfigure_auth()
 
             # Nothing to re-auth — save immediately
-            self.hass.config_entries.async_update_entry(entry, data=self._config_data)
+            self._update_entry_and_reload_if_needed(entry, self._config_data)
             return self.async_abort(reason="reconfigure_successful")
 
         # Defaults based purely on selected auth_type
@@ -844,30 +827,19 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_show_progress_done(next_step_id="reconfigure_button_timeout")
 
         self._confirm_task = None
-        session = aiohttp_client.async_get_clientsession(self.hass)
-        ssl_context = await create_unverified_ssl_context(self.hass)
-        try:
-            new_token = await self._async_request_app_auth_token(
-                session, host, HCU_REST_PORT, self._app_client_id,
-                self._app_client_auth, self._app_access_point_id, ssl_context,
-            )
-            new_client_id = await self._async_confirm_app_auth_token(
-                session, host, HCU_REST_PORT, self._app_client_id,
-                self._app_client_auth, new_token, self._app_access_point_id, ssl_context,
-            )
-        except Exception as exc:
-            _LOGGER.error("Failed to fetch App User token after button press: %s", exc)
-            return self.async_show_progress_done(next_step_id="reconfigure_button_timeout")
-
-        self._app_new_token = new_token
-        self._app_new_client_id = new_client_id
-        self._config_data[CONF_APP_TOKEN] = new_token
+        self._config_data[CONF_APP_TOKEN] = self._app_new_token
         self._config_data[CONF_HCU_SGTIN] = self._app_access_point_id
-        self._config_data[CONF_APP_CLIENT_ID] = new_client_id
+        self._config_data[CONF_APP_CLIENT_ID] = self._app_new_client_id
 
         if self._is_dual_setup and not self._keep_plugin_token:
             return self.async_show_progress_done(next_step_id="reconfigure_auth")
 
+        return self.async_show_progress_done(next_step_id="reconfigure_app_auth_finalize")
+
+    async def async_step_reconfigure_app_auth_finalize(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Save updated App User token and close the reconfigure flow."""
         entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
         updated_data = {
             k: v for k, v in entry.data.items()
@@ -875,15 +847,15 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
         }
         updated_data.update({
             CONF_HOST: self._config_data[CONF_HOST],
-            CONF_APP_TOKEN: new_token,
+            CONF_APP_TOKEN: self._app_new_token,
             CONF_AUTH_TYPE: AUTH_TYPE_DUAL if self._is_dual_setup else AUTH_TYPE_APP,
             CONF_HCU_SGTIN: self._app_access_point_id,
-            CONF_APP_CLIENT_ID: new_client_id,
+            CONF_APP_CLIENT_ID: self._app_new_client_id,
         })
         if self._is_dual_setup and self._keep_plugin_token:
             updated_data[CONF_PLUGIN_TOKEN] = entry.data.get(CONF_PLUGIN_TOKEN, "")
             updated_data[CONF_PLUGIN_CLIENT_ID] = entry.data.get(CONF_PLUGIN_CLIENT_ID, "")
-        self.hass.config_entries.async_update_entry(entry, data=updated_data)
+        self._update_entry_and_reload_if_needed(entry, updated_data)
         return self.async_abort(reason="reconfigure_successful")
 
     async def async_step_reconfigure_button_timeout(
@@ -891,6 +863,14 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Abort the reconfigure flow when the system button was not pressed in time."""
         return self.async_abort(reason="button_timeout")
+
+    def _update_entry_and_reload_if_needed(self, entry: ConfigEntry, data: dict) -> None:
+        """Update config entry and force reload when the entry is not currently loaded."""
+        self.hass.config_entries.async_update_entry(entry, data=data)
+        if entry.state is not ConfigEntryState.LOADED:
+            self.hass.async_create_task(
+                self.hass.config_entries.async_reload(entry.entry_id)
+            )
 
     def _get_device_name(self, with_timestamp: bool = False) -> str:
         """Build a device name from the HA instance name, optionally with timestamp."""
@@ -912,11 +892,19 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
         timeout: int = 60,
         interval: int = 2,
     ) -> None:
-        """Poll isRequestAcknowledged until the system button is pressed or timeout."""
+        """Poll isRequestAcknowledged, then fetch and store the App User token."""
         for _ in range(timeout // interval):
             if await self._async_is_request_acknowledged(
                 session, host, port, client_id, client_auth, access_point_id, ssl_context
             ):
+                new_token = await self._async_request_app_auth_token(
+                    session, host, port, client_id, client_auth, access_point_id, ssl_context,
+                )
+                new_client_id = await self._async_confirm_app_auth_token(
+                    session, host, port, client_id, client_auth, new_token, access_point_id, ssl_context,
+                )
+                self._app_new_token = new_token
+                self._app_new_client_id = new_client_id
                 return
             await asyncio.sleep(interval)
         raise asyncio.TimeoutError(

--- a/custom_components/hcu_integration/config_flow.py
+++ b/custom_components/hcu_integration/config_flow.py
@@ -14,7 +14,7 @@ from typing import Any, TYPE_CHECKING
 from datetime import datetime, timedelta
 
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
-from homeassistant.config_entries import ConfigEntry, ConfigEntryState, ConfigFlow, OptionsFlow
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
 from homeassistant.const import CONF_HOST, ATTR_TEMPERATURE
 from homeassistant.core import callback, HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
@@ -319,9 +319,26 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_show_progress_done(next_step_id="button_timeout")
 
         self._confirm_task = None
-        self._config_data[CONF_APP_TOKEN] = self._app_new_token
+        session = aiohttp_client.async_get_clientsession(self.hass)
+        ssl_context = await create_unverified_ssl_context(self.hass)
+        try:
+            new_token = await self._async_request_app_auth_token(
+                session, host, HCU_REST_PORT, self._app_client_id,
+                self._app_client_auth, self._app_access_point_id, ssl_context,
+            )
+            new_client_id = await self._async_confirm_app_auth_token(
+                session, host, HCU_REST_PORT, self._app_client_id,
+                self._app_client_auth, new_token, self._app_access_point_id, ssl_context,
+            )
+        except Exception as exc:
+            _LOGGER.error("Failed to fetch App User token after button press: %s", exc)
+            return self.async_show_progress_done(next_step_id="button_timeout")
+
+        self._app_new_token = new_token
+        self._app_new_client_id = new_client_id
+        self._config_data[CONF_APP_TOKEN] = new_token
         self._config_data[CONF_HCU_SGTIN] = self._app_access_point_id
-        self._config_data[CONF_APP_CLIENT_ID] = self._app_new_client_id
+        self._config_data[CONF_APP_CLIENT_ID] = new_client_id
 
         if self._is_dual_setup:
             return self.async_show_progress_done(next_step_id="auth")
@@ -563,7 +580,7 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
                     updated_data.pop(CONF_APP_TOKEN, None)
                     updated_data.pop(CONF_APP_CLIENT_ID, None)
                     updated_data.pop(CONF_HCU_SGTIN, None)
-                self._update_entry_and_reload_if_needed(entry, updated_data)
+                self.hass.config_entries.async_update_entry(entry, data=updated_data)
                 return self.async_abort(reason="reconfigure_successful")
 
             except aiohttp.ClientResponseError as err:
@@ -708,7 +725,7 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
                 return await self.async_step_reconfigure_auth()
 
             # Nothing to re-auth — save immediately
-            self._update_entry_and_reload_if_needed(entry, self._config_data)
+            self.hass.config_entries.async_update_entry(entry, data=self._config_data)
             return self.async_abort(reason="reconfigure_successful")
 
         # Defaults based purely on selected auth_type
@@ -827,19 +844,30 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_show_progress_done(next_step_id="reconfigure_button_timeout")
 
         self._confirm_task = None
-        self._config_data[CONF_APP_TOKEN] = self._app_new_token
+        session = aiohttp_client.async_get_clientsession(self.hass)
+        ssl_context = await create_unverified_ssl_context(self.hass)
+        try:
+            new_token = await self._async_request_app_auth_token(
+                session, host, HCU_REST_PORT, self._app_client_id,
+                self._app_client_auth, self._app_access_point_id, ssl_context,
+            )
+            new_client_id = await self._async_confirm_app_auth_token(
+                session, host, HCU_REST_PORT, self._app_client_id,
+                self._app_client_auth, new_token, self._app_access_point_id, ssl_context,
+            )
+        except Exception as exc:
+            _LOGGER.error("Failed to fetch App User token after button press: %s", exc)
+            return self.async_show_progress_done(next_step_id="reconfigure_button_timeout")
+
+        self._app_new_token = new_token
+        self._app_new_client_id = new_client_id
+        self._config_data[CONF_APP_TOKEN] = new_token
         self._config_data[CONF_HCU_SGTIN] = self._app_access_point_id
-        self._config_data[CONF_APP_CLIENT_ID] = self._app_new_client_id
+        self._config_data[CONF_APP_CLIENT_ID] = new_client_id
 
         if self._is_dual_setup and not self._keep_plugin_token:
             return self.async_show_progress_done(next_step_id="reconfigure_auth")
 
-        return self.async_show_progress_done(next_step_id="reconfigure_app_auth_finalize")
-
-    async def async_step_reconfigure_app_auth_finalize(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Save updated App User token and close the reconfigure flow."""
         entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
         updated_data = {
             k: v for k, v in entry.data.items()
@@ -847,15 +875,15 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
         }
         updated_data.update({
             CONF_HOST: self._config_data[CONF_HOST],
-            CONF_APP_TOKEN: self._app_new_token,
+            CONF_APP_TOKEN: new_token,
             CONF_AUTH_TYPE: AUTH_TYPE_DUAL if self._is_dual_setup else AUTH_TYPE_APP,
             CONF_HCU_SGTIN: self._app_access_point_id,
-            CONF_APP_CLIENT_ID: self._app_new_client_id,
+            CONF_APP_CLIENT_ID: new_client_id,
         })
         if self._is_dual_setup and self._keep_plugin_token:
             updated_data[CONF_PLUGIN_TOKEN] = entry.data.get(CONF_PLUGIN_TOKEN, "")
             updated_data[CONF_PLUGIN_CLIENT_ID] = entry.data.get(CONF_PLUGIN_CLIENT_ID, "")
-        self._update_entry_and_reload_if_needed(entry, updated_data)
+        self.hass.config_entries.async_update_entry(entry, data=updated_data)
         return self.async_abort(reason="reconfigure_successful")
 
     async def async_step_reconfigure_button_timeout(
@@ -863,14 +891,6 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Abort the reconfigure flow when the system button was not pressed in time."""
         return self.async_abort(reason="button_timeout")
-
-    def _update_entry_and_reload_if_needed(self, entry: ConfigEntry, data: dict) -> None:
-        """Update config entry and force reload when the entry is not currently loaded."""
-        self.hass.config_entries.async_update_entry(entry, data=data)
-        if entry.state is not ConfigEntryState.LOADED:
-            self.hass.async_create_task(
-                self.hass.config_entries.async_reload(entry.entry_id)
-            )
 
     def _get_device_name(self, with_timestamp: bool = False) -> str:
         """Build a device name from the HA instance name, optionally with timestamp."""
@@ -892,19 +912,11 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
         timeout: int = 60,
         interval: int = 2,
     ) -> None:
-        """Poll isRequestAcknowledged, then fetch and store the App User token."""
+        """Poll isRequestAcknowledged until the system button is pressed or timeout."""
         for _ in range(timeout // interval):
             if await self._async_is_request_acknowledged(
                 session, host, port, client_id, client_auth, access_point_id, ssl_context
             ):
-                new_token = await self._async_request_app_auth_token(
-                    session, host, port, client_id, client_auth, access_point_id, ssl_context,
-                )
-                new_client_id = await self._async_confirm_app_auth_token(
-                    session, host, port, client_id, client_auth, new_token, access_point_id, ssl_context,
-                )
-                self._app_new_token = new_token
-                self._app_new_client_id = new_client_id
                 return
             await asyncio.sleep(interval)
         raise asyncio.TimeoutError(

--- a/custom_components/hcu_integration/config_flow.py
+++ b/custom_components/hcu_integration/config_flow.py
@@ -14,7 +14,7 @@ from typing import Any, TYPE_CHECKING
 from datetime import datetime, timedelta
 
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
-from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState, ConfigFlow, OptionsFlow
 from homeassistant.const import CONF_HOST, ATTR_TEMPERATURE
 from homeassistant.core import callback, HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
@@ -134,6 +134,7 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
         self._refresh_app_token: bool = False
         self._refresh_plugin_token: bool = False
         self._keep_tokens: bool = False
+        self._confirm_task: asyncio.Task | None = None
 
 
     @staticmethod
@@ -289,56 +290,52 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_app_auth_confirm(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """App User setup: verify button press and fetch token."""
-        errors: dict[str, str] = {}
+        """App User setup: wait for system button press via background polling."""
         host = self._config_data[CONF_HOST]
-        auth_port = HCU_REST_PORT
 
-        if user_input is not None:
+        if self._confirm_task is None:
             session = aiohttp_client.async_get_clientsession(self.hass)
             ssl_context = await create_unverified_ssl_context(self.hass)
-            try:
-                acknowledged = await self._async_is_request_acknowledged(
-                    session, host, auth_port, self._app_client_id, self._app_client_auth,
+            self._confirm_task = self.hass.async_create_task(
+                self._wait_for_button(
+                    session, host, HCU_REST_PORT,
+                    self._app_client_id, self._app_client_auth,
                     self._app_access_point_id, ssl_context,
                 )
-                if not acknowledged:
-                    errors["base"] = "button_not_pressed"
-                else:
-                    new_token = await self._async_request_app_auth_token(
-                        session, host, auth_port, self._app_client_id, self._app_client_auth,
-                        self._app_access_point_id, ssl_context,
-                    )
-                    new_client_id = await self._async_confirm_app_auth_token(
-                        session, host, auth_port, self._app_client_id, self._app_client_auth,
-                        new_token, self._app_access_point_id, ssl_context,
-                    )
-                    self._app_new_token = new_token
-                    self._app_new_client_id = new_client_id
-                    # Store App User data; auth_type + plugin fields set after Plugin step (if dual)
-                    self._config_data[CONF_APP_TOKEN] = self._app_new_token
-                    self._config_data[CONF_HCU_SGTIN] = self._app_access_point_id
-                    self._config_data[CONF_APP_CLIENT_ID] = self._app_new_client_id
-                    if self._is_dual_setup:
-                        return await self.async_step_auth()
-                    self._config_data.pop(CONF_PLUGIN_TOKEN, None)
-                    self._config_data.pop(CONF_PLUGIN_CLIENT_ID, None)
-                    self._config_data[CONF_AUTH_TYPE] = AUTH_TYPE_APP
-                    return await self.async_step_select_oems()
-            except (aiohttp.ClientError, asyncio.TimeoutError):
-                errors["base"] = "cannot_connect"
-            except ValueError:
-                errors["base"] = "invalid_key"
-            except Exception:
-                _LOGGER.exception("Unexpected error during App User token confirmation")
-                errors["base"] = "unknown"
+            )
 
-        return self.async_show_form(
-            step_id="app_auth_confirm",
-            data_schema=vol.Schema({}),
-            description_placeholders={"hcu_ip": host},
-            errors=errors,
-        )
+        if not self._confirm_task.done():
+            return self.async_show_progress(
+                step_id="app_auth_confirm",
+                progress_action="wait_for_button",
+                progress_task=self._confirm_task,
+            )
+
+        try:
+            self._confirm_task.result()
+        except Exception as exc:
+            _LOGGER.error("System button confirmation failed: %s", exc)
+            self._confirm_task = None
+            return self.async_show_progress_done(next_step_id="button_timeout")
+
+        self._confirm_task = None
+        self._config_data[CONF_APP_TOKEN] = self._app_new_token
+        self._config_data[CONF_HCU_SGTIN] = self._app_access_point_id
+        self._config_data[CONF_APP_CLIENT_ID] = self._app_new_client_id
+
+        if self._is_dual_setup:
+            return self.async_show_progress_done(next_step_id="auth")
+
+        self._config_data.pop(CONF_PLUGIN_TOKEN, None)
+        self._config_data.pop(CONF_PLUGIN_CLIENT_ID, None)
+        self._config_data[CONF_AUTH_TYPE] = AUTH_TYPE_APP
+        return self.async_show_progress_done(next_step_id="select_oems")
+
+    async def async_step_button_timeout(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Abort the flow when the system button was not pressed in time."""
+        return self.async_abort(reason="button_timeout")
 
     async def async_step_auth(
         self, user_input: dict[str, Any] | None = None
@@ -566,7 +563,7 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
                     updated_data.pop(CONF_APP_TOKEN, None)
                     updated_data.pop(CONF_APP_CLIENT_ID, None)
                     updated_data.pop(CONF_HCU_SGTIN, None)
-                self.hass.config_entries.async_update_entry(entry, data=updated_data)
+                self._update_entry_and_reload_if_needed(entry, updated_data)
                 return self.async_abort(reason="reconfigure_successful")
 
             except aiohttp.ClientResponseError as err:
@@ -711,7 +708,7 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
                 return await self.async_step_reconfigure_auth()
 
             # Nothing to re-auth — save immediately
-            self.hass.config_entries.async_update_entry(entry, data=self._config_data)
+            self._update_entry_and_reload_if_needed(entry, self._config_data)
             return self.async_abort(reason="reconfigure_successful")
 
         # Defaults based purely on selected auth_type
@@ -801,69 +798,117 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_reconfigure_app_auth_confirm(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Confirm App User auth: check button press, then fetch and store token."""
-        errors = {}
+        """Reconfigure App User auth: wait for system button press via background polling."""
         host = self._config_data[CONF_HOST]
-        auth_port = HCU_REST_PORT
 
-        if user_input is not None:
+        if self._confirm_task is None:
             session = aiohttp_client.async_get_clientsession(self.hass)
             ssl_context = await create_unverified_ssl_context(self.hass)
-            try:
-                acknowledged = await self._async_is_request_acknowledged(
-                    session, host, auth_port, self._app_client_id, self._app_client_auth,
-                    self._app_access_point_id, ssl_context
+            self._confirm_task = self.hass.async_create_task(
+                self._wait_for_button(
+                    session, host, HCU_REST_PORT,
+                    self._app_client_id, self._app_client_auth,
+                    self._app_access_point_id, ssl_context,
                 )
-                if not acknowledged:
-                    errors["base"] = "button_not_pressed"
-                else:
-                    new_token = await self._async_request_app_auth_token(
-                        session, host, auth_port, self._app_client_id, self._app_client_auth,
-                        self._app_access_point_id, ssl_context
-                    )
-                    new_client_id = await self._async_confirm_app_auth_token(
-                        session, host, auth_port, self._app_client_id, self._app_client_auth,
-                        new_token, self._app_access_point_id, ssl_context
-                    )
-                    self._app_new_token = new_token
-                    self._app_new_client_id = new_client_id
-                    # Store app data in _config_data for use by reconfigure_auth if dual
-                    self._config_data[CONF_APP_TOKEN] = self._app_new_token
-                    self._config_data[CONF_HCU_SGTIN] = self._app_access_point_id
-                    self._config_data[CONF_APP_CLIENT_ID] = self._app_new_client_id
-                    if self._is_dual_setup and not self._keep_plugin_token:
-                        return await self.async_step_reconfigure_auth()
-                    entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
-                    updated_data = {
-                        k: v for k, v in entry.data.items()
-                        if k not in (CONF_PLUGIN_TOKEN, CONF_PLUGIN_CLIENT_ID)
-                    }
-                    updated_data.update({
-                        CONF_HOST: self._config_data[CONF_HOST],
-                        CONF_APP_TOKEN: self._app_new_token,
-                        CONF_AUTH_TYPE: AUTH_TYPE_DUAL if self._is_dual_setup else AUTH_TYPE_APP,
-                        CONF_HCU_SGTIN: self._app_access_point_id,
-                        CONF_APP_CLIENT_ID: self._app_new_client_id,
-                    })
-                    if self._is_dual_setup and self._keep_plugin_token:
-                        updated_data[CONF_PLUGIN_TOKEN] = entry.data.get(CONF_PLUGIN_TOKEN, "")
-                        updated_data[CONF_PLUGIN_CLIENT_ID] = entry.data.get(CONF_PLUGIN_CLIENT_ID, "")
-                    self.hass.config_entries.async_update_entry(entry, data=updated_data)
-                    return self.async_abort(reason="reconfigure_successful")
+            )
 
-            except (aiohttp.ClientError, asyncio.TimeoutError):
-                errors["base"] = "cannot_connect"
-            except ValueError:
-                errors["base"] = "invalid_key"
-            except Exception:
-                _LOGGER.exception("Unexpected error during App User token confirmation.")
-                errors["base"] = "unknown"
+        if not self._confirm_task.done():
+            return self.async_show_progress(
+                step_id="reconfigure_app_auth_confirm",
+                progress_action="wait_for_button",
+                progress_task=self._confirm_task,
+            )
 
-        return self.async_show_form(
-            step_id="reconfigure_app_auth_confirm",
-            data_schema=vol.Schema({}),
-            description_placeholders={"hcu_ip": host},
-            errors=errors,
+        try:
+            self._confirm_task.result()
+        except Exception as exc:
+            _LOGGER.error("System button confirmation failed during reconfigure: %s", exc)
+            self._confirm_task = None
+            return self.async_show_progress_done(next_step_id="reconfigure_button_timeout")
+
+        self._confirm_task = None
+        self._config_data[CONF_APP_TOKEN] = self._app_new_token
+        self._config_data[CONF_HCU_SGTIN] = self._app_access_point_id
+        self._config_data[CONF_APP_CLIENT_ID] = self._app_new_client_id
+
+        if self._is_dual_setup and not self._keep_plugin_token:
+            return self.async_show_progress_done(next_step_id="reconfigure_auth")
+
+        return self.async_show_progress_done(next_step_id="reconfigure_app_auth_finalize")
+
+    async def async_step_reconfigure_app_auth_finalize(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Save updated App User token and close the reconfigure flow."""
+        entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        updated_data = {
+            k: v for k, v in entry.data.items()
+            if k not in (CONF_PLUGIN_TOKEN, CONF_PLUGIN_CLIENT_ID)
+        }
+        updated_data.update({
+            CONF_HOST: self._config_data[CONF_HOST],
+            CONF_APP_TOKEN: self._app_new_token,
+            CONF_AUTH_TYPE: AUTH_TYPE_DUAL if self._is_dual_setup else AUTH_TYPE_APP,
+            CONF_HCU_SGTIN: self._app_access_point_id,
+            CONF_APP_CLIENT_ID: self._app_new_client_id,
+        })
+        if self._is_dual_setup and self._keep_plugin_token:
+            updated_data[CONF_PLUGIN_TOKEN] = entry.data.get(CONF_PLUGIN_TOKEN, "")
+            updated_data[CONF_PLUGIN_CLIENT_ID] = entry.data.get(CONF_PLUGIN_CLIENT_ID, "")
+        self._update_entry_and_reload_if_needed(entry, updated_data)
+        return self.async_abort(reason="reconfigure_successful")
+
+    async def async_step_reconfigure_button_timeout(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Abort the reconfigure flow when the system button was not pressed in time."""
+        return self.async_abort(reason="button_timeout")
+
+    def _update_entry_and_reload_if_needed(self, entry: ConfigEntry, data: dict) -> None:
+        """Update config entry and force reload when the entry is not currently loaded."""
+        self.hass.config_entries.async_update_entry(entry, data=data)
+        if entry.state is not ConfigEntryState.LOADED:
+            self.hass.async_create_task(
+                self.hass.config_entries.async_reload(entry.entry_id)
+            )
+
+    def _get_device_name(self, with_timestamp: bool = False) -> str:
+        """Build a device name from the HA instance name, optionally with timestamp."""
+        instance_name = self.hass.config.location_name or "Home Assistant"
+        if with_timestamp:
+            timestamp = datetime.now().strftime("%d.%m.%Y %H:%M")
+            return f"{instance_name} - {timestamp}"
+        return instance_name
+
+    async def _wait_for_button(
+        self,
+        session: aiohttp.ClientSession,
+        host: str,
+        port: int,
+        client_id: str,
+        client_auth: str,
+        access_point_id: str,
+        ssl_context,
+        timeout: int = 60,
+        interval: int = 2,
+    ) -> None:
+        """Poll isRequestAcknowledged, then fetch and store the App User token."""
+        for _ in range(timeout // interval):
+            if await self._async_is_request_acknowledged(
+                session, host, port, client_id, client_auth, access_point_id, ssl_context
+            ):
+                new_token = await self._async_request_app_auth_token(
+                    session, host, port, client_id, client_auth, access_point_id, ssl_context,
+                )
+                new_client_id = await self._async_confirm_app_auth_token(
+                    session, host, port, client_id, client_auth, new_token, access_point_id, ssl_context,
+                )
+                self._app_new_token = new_token
+                self._app_new_client_id = new_client_id
+                return
+            await asyncio.sleep(interval)
+        raise asyncio.TimeoutError(
+            f"System button on HCU at {host} was not pressed within {timeout} seconds."
         )
 
     async def _async_connection_request(
@@ -888,7 +933,7 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
             headers["PIN"] = system_pin
         body: dict[str, str] = {
             "deviceId": client_id,
-            "deviceName": PLUGIN_FRIENDLY_NAME.get("en", "Home Assistant Integration"),
+            "deviceName": self._get_device_name(),
             "sgtin": access_point_id,
         }
         _LOGGER.debug("connectionRequest → %s | headers=%s | body=%s", url, list(headers), body)
@@ -988,10 +1033,11 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
         """Request a new auth token from the HCU."""
         url = f"https://{host}:{port}/hmip/auth/requestConnectApiAuthToken"
         headers = {"VERSION": "12"}
+        device_name = self._get_device_name(with_timestamp=True)
         body = {
             "activationKey": key,
             "pluginId": PLUGIN_ID,
-            "friendlyName": PLUGIN_FRIENDLY_NAME,
+            "friendlyName": {"de": device_name, "en": device_name},
         }
 
         _LOGGER.debug("requestConnectApiAuthToken → %s", url)

--- a/custom_components/hcu_integration/translations/de.json
+++ b/custom_components/hcu_integration/translations/de.json
@@ -25,7 +25,7 @@
       },
       "app_auth_init": {
         "title": "App-Benutzer: Verbindung anfragen",
-        "description": "Die Verbindungsanfrage wird an {hcu_ip} gesendet.\n\nDrücke danach die **Systemtaste** an deiner HCU und klicke auf **Weiter**.\n\n{debug_info}",
+        "description": "Die Verbindungsanfrage wird an {hcu_ip} gesendet.\n\nDrücke danach die **Systemtaste** an deiner HCU und klicke auf **OK**.\n\n{debug_info}",
         "data": {
           "sgtin": "HCU SGTIN (wird automatisch erkannt)"
         },
@@ -34,8 +34,8 @@
         }
       },
       "app_auth_confirm": {
-        "title": "App-Benutzer: Verbindung bestätigen",
-        "description": "Hast du die Systemtaste an {hcu_ip} gedrückt? Klicke auf **OK**, um die Authentifizierung abzuschließen.\n\nFalls die Systemtaste noch nicht gedrückt wurde, drücke sie jetzt und versuche es erneut."
+        "title": "App-Benutzer: Warte auf Systemtaste",
+        "description": "Bitte drücke jetzt die **Systemtaste** an deiner HCU ({hcu_ip}).\n\nDie Integration wartet automatisch auf die Bestätigung..."
       },
       "auth": {
         "title": "Mit HCU authentifizieren",
@@ -95,7 +95,7 @@
       },
       "reconfigure_app_auth_init": {
         "title": "App-Benutzer: Verbindung anfragen",
-        "description": "Die Verbindungsanfrage wird an {hcu_ip} gesendet.\n\nDrücke danach die **Systemtaste** an deiner HCU und klicke auf **Weiter**.\n\n{debug_info}",
+        "description": "Die Verbindungsanfrage wird an {hcu_ip} gesendet.\n\nDrücke danach die **Systemtaste** an deiner HCU und klicke auf **OK**.\n\n{debug_info}",
         "data": {
           "sgtin": "HCU SGTIN (wird automatisch erkannt)"
         },
@@ -104,8 +104,8 @@
         }
       },
       "reconfigure_app_auth_confirm": {
-        "title": "App-Benutzer: Verbindung bestätigen",
-        "description": "Hast du die Systemtaste an {hcu_ip} gedrückt? Klicke auf **OK**, um die Authentifizierung abzuschließen.\n\nFalls die Systemtaste noch nicht gedrückt wurde, drücke sie jetzt und versuche es erneut."
+        "title": "App-Benutzer: Warte auf Systemtaste",
+        "description": "Bitte drücke jetzt die **Systemtaste** an deiner HCU ({hcu_ip}).\n\nDie Integration wartet automatisch auf die Bestätigung..."
       }
     },
     "error": {
@@ -114,6 +114,7 @@
       "invalid_config": "Ungültige Konfiguration oder Antwort von der HCU. Bitte überprüfen Sie Ihre Einstellungen.",
       "api_error": "Ein unerwarteter API-Fehler ist aufgetreten.",
       "button_not_pressed": "Die Systemtaste an der HCU wurde noch nicht gedrückt. Bitte drücken und erneut versuchen.",
+      "button_timeout": "Zeitüberschreitung beim Warten auf die Systemtaste. Bitte richte die Integration erneut ein und drücke die Taste innerhalb von 60 Sekunden.",
       "select_at_least_one": "Bitte wähle mindestens eine Verbindungsart aus.",
       "unknown": "Ein unbekannter Fehler ist aufgetreten."
     },
@@ -122,7 +123,8 @@
       "internal_error": "Ein interner Fehler ist aufgetreten.",
       "no_ipv4_address": "Die entdeckte HCU hat keine erreichbare IPv4-Adresse.",
       "reauth_successful": "Neu-Authentifizierung war erfolgreich.",
-      "reconfigure_successful": "Rekonfiguration war erfolgreich."
+      "reconfigure_successful": "Rekonfiguration war erfolgreich.",
+      "button_timeout": "Zeitüberschreitung beim Warten auf die Systemtaste. Die Einrichtung wurde abgebrochen."
     }
   },
   "options": {

--- a/custom_components/hcu_integration/translations/en.json
+++ b/custom_components/hcu_integration/translations/en.json
@@ -25,7 +25,7 @@
       },
       "app_auth_init": {
         "title": "App User: Request Connection",
-        "description": "A connection request will be sent to {hcu_ip}.\n\nAfterwards press the **system button** on your HCU, then click **Submit**.\n\n{debug_info}",
+        "description": "A connection request will be sent to {hcu_ip}.\n\nAfterwards press the **system button** on your HCU, then click **OK**.\n\n{debug_info}",
         "data": {
           "sgtin": "HCU SGTIN (auto-detected)"
         },
@@ -34,8 +34,8 @@
         }
       },
       "app_auth_confirm": {
-        "title": "App User: Confirm Connection",
-        "description": "Have you pressed the system button on {hcu_ip}? Click **OK** to complete authentication.\n\nIf the system button has not been pressed yet, press it now and try again."
+        "title": "App User: Waiting for System Button",
+        "description": "Please press the **system button** on your HCU ({hcu_ip}) now.\n\nThe integration is waiting for confirmation automatically..."
       },
       "auth": {
         "title": "Authenticate with HCU",
@@ -95,7 +95,7 @@
       },
       "reconfigure_app_auth_init": {
         "title": "App User: Request Connection",
-        "description": "A connection request will be sent to {hcu_ip}.\n\nAfterwards press the **system button** on your HCU, then click **Submit**.\n\n{debug_info}",
+        "description": "A connection request will be sent to {hcu_ip}.\n\nAfterwards press the **system button** on your HCU, then click **OK**.\n\n{debug_info}",
         "data": {
           "sgtin": "HCU SGTIN (auto-detected)"
         },
@@ -104,8 +104,8 @@
         }
       },
       "reconfigure_app_auth_confirm": {
-        "title": "App User: Confirm Connection",
-        "description": "Have you pressed the system button on {hcu_ip}? Click **OK** to complete authentication.\n\nIf the system button has not been pressed yet, press it now and try again."
+        "title": "App User: Waiting for System Button",
+        "description": "Please press the **system button** on your HCU ({hcu_ip}) now.\n\nThe integration is waiting for confirmation automatically..."
       }
     },
     "error": {
@@ -114,6 +114,7 @@
       "invalid_config": "Invalid configuration or response from HCU. Please check your settings.",
       "api_error": "An unexpected API error occurred.",
       "button_not_pressed": "The system button on the HCU has not been pressed yet. Please press it and try again.",
+      "button_timeout": "Timed out waiting for the system button. Please restart setup and press the button within 60 seconds.",
       "select_at_least_one": "Please select at least one connection type.",
       "unknown": "An unknown error occurred."
     },
@@ -122,7 +123,8 @@
       "internal_error": "An internal error occurred.",
       "no_ipv4_address": "The discovered HCU has no reachable IPv4 address.",
       "reauth_successful": "Re-authentication was successful.",
-      "reconfigure_successful": "Re-configuration was successful."
+      "reconfigure_successful": "Re-configuration was successful.",
+      "button_timeout": "Timed out waiting for the system button. Setup has been aborted."
     }
   },
   "options": {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **async_show_progress für Systemtaste:** Der manuelle "Hast du die Taste gedrückt?"-Dialog wurde ersetzt durch einen automatischen Hintergrund-Task (`_wait_for_button`), der alle 2 Sekunden `isRequestAcknowledged` pollt (max. 60 Sekunden). HA zeigt währenddessen automatisch einen Ladebalken. Bei Timeout wird der Flow mit `button_timeout` abgebrochen. Gilt für Setup- und Rekonfigurationsflow.
- **HA-Instanzname als Device Name:** App User erhält `location_name` (z.B. `"Zuhause"`) als `deviceName`. Plugin User erhält `location_name + Timestamp` (z.B. `"Zuhause - 15.06.2026 14:20"`) als `friendlyName`, um Registrierungen unterscheidbar zu halten.

## Test plan

- [ ] App User Setup: Systemtaste drücken → Spinner erscheint, Flow schreitet automatisch fort
- [ ] App User Setup: Taste **nicht** drücken → nach 60 s Abbruch mit `button_timeout`
- [ ] Rekonfiguration App User: gleiches Verhalten
- [ ] Plugin User Setup: `friendlyName` enthält Instanzname + Datum/Uhrzeit
- [ ] App User Setup: `deviceName` enthält nur den Instanznamen (kein Timestamp)
- [ ] hassfest Validierung fehlerfrei
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QtYeM2N96PBWECTH3yUnjX)_